### PR TITLE
Add a copy/pastable link to auto-login email

### DIFF
--- a/api/src/services/Mailer.ts
+++ b/api/src/services/Mailer.ts
@@ -35,7 +35,19 @@ const sendEmailWithAutoLoginUrl = ({
 		from: "no-reply@tradarchive.com",
 		subject: "Your login for Trad Archive",
 		text: `Hi ${user.username}, click this link to log in to Trad Archive: ${autoLoginUrl} . It will be valid for the next 10 minutes. If you didn't request this, you can ignore this email.`,
-		html: `Hi ${user.username},<br /><br /><a href="${autoLoginUrl}">Click here to log in to Trad Archive</a><br /><br />This link will be valid for the next 10 minutes. If you didn't request it, you can ignore this email.`,
+		html: `
+			Hi ${user.username},
+			<br /><br />
+			<a href="${autoLoginUrl}">Click here to log in to Trad Archive</a>
+			<br /><br />
+			This link will be valid for the next 10 minutes.
+			<br /><br />
+			- - -
+			<br /><br />
+			If it doesn't work, copy and paste this URL into your browser:
+			<br /><br />
+			<em>${autoLoginUrl}</em>
+		`,
 	};
 
 	return sendEmail(data);


### PR DESCRIPTION
Closes #44 

- For some users, clicking a link in an email won't work to log in
  - For example, if you're on iOS and using a custom email app that opens an embedded browser 
  - Often embedded browsers don't share cookies with your main browser so the login won't carry over
- This PR adds a copy/pastable link in the auto-login email
- You can paste it into a web browser of your choice and log in that way

<img width="699" alt="Screen Shot 2021-11-25 at 11 03 40 AM" src="https://user-images.githubusercontent.com/1173791/143430636-cd1b0488-f6db-4220-b7ba-b0935bbcdc13.png">
