### PR TITLE
Implement pagination; Improve browsing experience for Entity pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,17 @@ With this project, community members can...
 > yarn dev
 ```
 
-### Migrations
+### Updating DB Schema
 
 ```sh
 # Switch to api directory
 cd api
 
-# Add the migration you'd like to run in `src/migration.sql`
+# Add the SQL commands you'd like to run in `src/migration.sql`
 ...
 ALTER TABLE user ADD COLUMN test varchar(255);
 ...
 
-# Apply the migration simultaneously to your local MYSQL DB and the PlanetScale DB branch. If the migration succeeds, update `src/seed/init-db-schema.sql` with the new schema.
+# Apply the migration simultaneously to your local MYSQL DB and the PlanetScale DB branch. If the migration succeeds, it will then update `src/seed/init-db-schema.sql` with the new schema.
 > make migrate
 ```

--- a/api/src/resolvers/AudioItemResolver.ts
+++ b/api/src/resolvers/AudioItemResolver.ts
@@ -23,6 +23,7 @@ import {
 	AudioItemsCreatedByUserInput,
 	CreateAudioItemInput,
 	UpdateAudioItemInput,
+	AudioItemsTaggedWithEntityResponse,
 } from "./AudioItemResolverTypes";
 import EntityService from "../services/Entity";
 import { EntityStatus } from "../models/entities/base";
@@ -95,8 +96,8 @@ export class AudioItemResolver {
 		return audioItems;
 	}
 
-	@Query(() => [AudioItem])
-	audioItemsTaggedWithEntity(
+	@Query(() => AudioItemsTaggedWithEntityResponse)
+	async audioItemsTaggedWithEntity(
 		@Arg("input") input: AudioItemsTaggedWithEntityInput
 	) {
 		const { entityType, entityId, take, skip, sortBy } = input;
@@ -127,7 +128,11 @@ export class AudioItemResolver {
 			default:
 				break;
 		}
-		return query.getMany();
+		const results = await query.getManyAndCount();
+		return {
+			audioItems: results[0],
+			total: results[1],
+		};
 	}
 
 	@Query(() => [AudioItem])

--- a/api/src/resolvers/AudioItemResolverTypes.ts
+++ b/api/src/resolvers/AudioItemResolverTypes.ts
@@ -1,5 +1,6 @@
-import { InputType, Field, Int } from "type-graphql";
+import { InputType, Field, Int, ObjectType } from "type-graphql";
 import { EntityStatus, EntityType } from "../models/entities/base";
+import { AudioItem } from "../models/entities/AudioItem";
 import { SortBy } from "./commonTypes";
 
 @InputType()
@@ -39,6 +40,15 @@ export class AudioItemsTaggedWithEntityInput {
 		defaultValue: SortBy.RecentlyTagged,
 	})
 	sortBy?: SortBy;
+}
+
+@ObjectType()
+export class AudioItemsTaggedWithEntityResponse {
+	@Field(() => [AudioItem])
+	audioItems!: AudioItem[];
+
+	@Field(() => Int)
+	total!: number;
 }
 
 @InputType()

--- a/web/apolloClient.ts
+++ b/web/apolloClient.ts
@@ -64,19 +64,6 @@ export const apolloClient = new ApolloClient({
 							return merged;
 						},
 					},
-					audioItemsTaggedWithEntity: {
-						// Namespace cached results for this query based on requested
-						// entity ID
-						keyArgs: (args) => args.input.entityId,
-						merge(existing = [], incoming, { args: { input } }) {
-							const { skip = 0 } = input;
-							const merged = existing ? existing.slice(0) : [];
-							for (let i = 0; i < incoming.length; ++i) {
-								merged[skip + i] = incoming[i];
-							}
-							return merged;
-						},
-					},
 					collections: {
 						// Cache separately based on the sortBy value
 						keyArgs: ["input", ["sortBy"]],

--- a/web/components/AudioItemCard.tsx
+++ b/web/components/AudioItemCard.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
+import { useRouter } from "next/router";
 
 import {
 	AudioItem,
@@ -28,7 +29,7 @@ const AudioItemCard = ({ audioItem, showTitle = true, className }: Props) => {
 	const { name, slug, description, tags, status, createdByUser, createdAt } =
 		audioItem;
 
-	const [_, { refetch }] = useAudioItem({ slug });
+	const router = useRouter();
 
 	const {
 		activeAudioItem,
@@ -68,10 +69,10 @@ const AudioItemCard = ({ audioItem, showTitle = true, className }: Props) => {
 	const onTakedownRequestCreated = useCallback(
 		(takedownRequest: TakedownRequest) => {
 			if (takedownRequest.status === TakedownRequestStatus.Approved) {
-				refetch();
+				router.push(`/entities/audio-items/${slug}`);
 			}
 		},
-		[refetch]
+		[router, slug]
 	);
 
 	const shouldShowPositionAndDuration =

--- a/web/components/Breadcrumb.tsx
+++ b/web/components/Breadcrumb.tsx
@@ -7,11 +7,10 @@ interface BreadcrumbItem {
 
 interface Props {
 	items: BreadcrumbItem[];
-	uniformItems?: boolean;
 	className?: string;
 }
 
-const Breadcrumb = ({ items = [], uniformItems = false, className }: Props) => {
+const Breadcrumb = ({ items = [], className }: Props) => {
 	if (items.length === 0) {
 		return null;
 	}
@@ -37,12 +36,9 @@ const Breadcrumb = ({ items = [], uniformItems = false, className }: Props) => {
 						</i>
 					</div>
 				))}
-				{uniformItems && (
-					<span className="text-black font-bold">{finalItem.label}</span>
-				)}
 			</div>
 
-			{!uniformItems && <h1>{finalItem.label}</h1>}
+			<h1>{finalItem.label}</h1>
 		</div>
 	);
 };

--- a/web/components/Breadcrumb.tsx
+++ b/web/components/Breadcrumb.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link";
+
+interface BreadcrumbItem {
+	label: string;
+	href?: string;
+}
+
+interface Props {
+	items: BreadcrumbItem[];
+	className?: string;
+}
+
+const Breadcrumb = ({ items = [], className }: Props) => {
+	if (items.length === 0) {
+		return null;
+	}
+	if (items.length === 1) {
+		return <h1 className={className ?? ""}>{items[0].label}</h1>;
+	}
+	const subItems = items.slice(0, items.length - 1);
+	const finalItem = items[items.length - 1];
+	return (
+		<div className={`flex flex-col ${className ?? ""}`}>
+			<div className="flex flex-row items-center mb-1">
+				{subItems.map(({ label, href }, index) => (
+					<div className="flex" key={index}>
+						{href ? (
+							<Link href={href}>{label}</Link>
+						) : (
+							<span className="text-gray">{label}</span>
+						)}
+						<i className="material-icons text-gray-500 text-base ml-1">
+							keyboard_arrow_right
+						</i>
+					</div>
+				))}
+			</div>
+			<h1>{finalItem.label}</h1>
+		</div>
+	);
+};
+
+export default Breadcrumb;

--- a/web/components/Breadcrumb.tsx
+++ b/web/components/Breadcrumb.tsx
@@ -27,7 +27,7 @@ const Breadcrumb = ({ items = [], className }: Props) => {
 						{href ? (
 							<Link href={href}>{label}</Link>
 						) : (
-							<span className="text-gray">{label}</span>
+							<span className="text-gray-500">{label}</span>
 						)}
 						<i className="material-icons text-gray-500 text-base ml-1">
 							keyboard_arrow_right

--- a/web/components/Breadcrumb.tsx
+++ b/web/components/Breadcrumb.tsx
@@ -7,18 +7,21 @@ interface BreadcrumbItem {
 
 interface Props {
 	items: BreadcrumbItem[];
+	uniformItems?: boolean;
 	className?: string;
 }
 
-const Breadcrumb = ({ items = [], className }: Props) => {
+const Breadcrumb = ({ items = [], uniformItems = false, className }: Props) => {
 	if (items.length === 0) {
 		return null;
 	}
 	if (items.length === 1) {
 		return <h1 className={className ?? ""}>{items[0].label}</h1>;
 	}
+
 	const subItems = items.slice(0, items.length - 1);
 	const finalItem = items[items.length - 1];
+
 	return (
 		<div className={`flex flex-col ${className ?? ""}`}>
 			<div className="flex flex-row items-center mb-1">
@@ -34,8 +37,12 @@ const Breadcrumb = ({ items = [], className }: Props) => {
 						</i>
 					</div>
 				))}
+				{uniformItems && (
+					<span className="text-black font-bold">{finalItem.label}</span>
+				)}
 			</div>
-			<h1>{finalItem.label}</h1>
+
+			{!uniformItems && <h1>{finalItem.label}</h1>}
 		</div>
 	);
 };

--- a/web/components/EditTagsButton.tsx
+++ b/web/components/EditTagsButton.tsx
@@ -40,8 +40,9 @@ interface Props {
 	entity: Entity;
 	className?: string;
 	children?: React.ReactChild | React.ReactChild[];
+	onSuccess?: () => void;
 }
-const EditTagsButton = ({ entity, className, children }: Props) => {
+const EditTagsButton = ({ entity, className, children, onSuccess }: Props) => {
 	const { currentUser, requireLogin } = useRequireLogin();
 
 	const [editTagsModalIsVisible, setEditTagsModalIsVisible] = useState(false);
@@ -79,12 +80,16 @@ const EditTagsButton = ({ entity, className, children }: Props) => {
 		};
 		if (deleteTagData?.deleteTag) {
 			onDeleteSuccess();
+			if (onSuccess) {
+				onSuccess();
+			}
 		}
 	}, [
 		deleteTagData,
 		getParentEntity,
 		setEditTagsModalIsVisible,
 		refetchTopLevelTags,
+		onSuccess,
 	]);
 
 	const { tags } = entity;

--- a/web/components/Filters.tsx
+++ b/web/components/Filters.tsx
@@ -57,18 +57,18 @@ const Filters = ({
 	}, [totalPages]);
 
 	const perPageOptions = useMemo(() => {
-		const ouptut: React.ReactNode[] = [];
+		const output: React.ReactNode[] = [];
 		for (const value in PerPage) {
 			if (isNaN(Number(value))) {
 				continue;
 			}
-			ouptut.push(
+			output.push(
 				<option value={value} key={value}>
 					{value}
 				</option>
 			);
 		}
-		return ouptut;
+		return output;
 	}, []);
 
 	return (

--- a/web/components/Filters.tsx
+++ b/web/components/Filters.tsx
@@ -46,7 +46,11 @@ const Filters = ({
 		const output: React.ReactNode[] = [];
 		let i = 1;
 		while (i <= totalPages) {
-			output.push(<option value={i}>{i}</option>);
+			output.push(
+				<option value={i} key={i}>
+					{i}
+				</option>
+			);
 			i++;
 		}
 		return output;
@@ -58,7 +62,11 @@ const Filters = ({
 			if (isNaN(Number(value))) {
 				continue;
 			}
-			ouptut.push(<option value={value}>{value}</option>);
+			ouptut.push(
+				<option value={value} key={value}>
+					{value}
+				</option>
+			);
 		}
 		return ouptut;
 	}, []);

--- a/web/components/Filters.tsx
+++ b/web/components/Filters.tsx
@@ -1,8 +1,7 @@
-import React, { useCallback } from "react";
-import { FilterType, SortBy, ViewAs } from "types";
+import React from "react";
+import { SortBy, ViewAs } from "types";
 
 export interface Props {
-	types?: Array<FilterType>;
 	sortBy?: SortBy;
 	onChangeSortBy?: (event: React.ChangeEvent<HTMLSelectElement>) => void;
 	viewAs?: ViewAs;
@@ -11,63 +10,14 @@ export interface Props {
 }
 
 const Filters = ({
-	types = [],
 	sortBy,
 	onChangeSortBy,
 	viewAs,
 	onChangeViewAs,
 	className,
 }: Props) => {
-	if (types.length === 0) {
-		return null;
-	}
-
-	const renderSortBy = useCallback(
-		(key) => {
-			if (!types.includes(FilterType.SortBy) || (!sortBy && !onChangeSortBy)) {
-				return null;
-			}
-			return (
-				<div
-					className={`flex flex-row items-center mr-0 md:mb-0 ${
-						types.length > 1 ? "mb-2 md:mr-6" : ""
-					}`}
-					key={key}
-				>
-					Sort by
-					<select className="ml-2" value={sortBy} onChange={onChangeSortBy}>
-						<option value={SortBy.RecentlyTagged}>Recently tagged</option>
-						<option value={SortBy.RecentlyAdded}>Recently added</option>
-					</select>
-				</div>
-			);
-		},
-		[types, sortBy, onChangeSortBy]
-	);
-
-	const renderViewAs = useCallback(
-		(key) => {
-			if (!types.includes(FilterType.ViewAs) || (!viewAs && !onChangeViewAs)) {
-				return null;
-			}
-			return (
-				<div
-					className={`flex flex-row items-center mr-0 md:mb-0 ${
-						types.length > 1 ? "mb-2 md:mr-6" : ""
-					}`}
-					key={key}
-				>
-					View as
-					<select className="ml-2" value={viewAs} onChange={onChangeViewAs}>
-						<option value={ViewAs.Card}>Cards</option>
-						<option value={ViewAs.Compact}>Compact</option>
-						<option value={ViewAs.List}>List</option>
-					</select>
-				</div>
-			);
-		},
-		[types, viewAs, onChangeViewAs]
-	);
+	const shouldRenderSortBy = sortBy && onChangeSortBy;
+	const shouldRenderViewAs = viewAs && onChangeViewAs;
 
 	return (
 		<div
@@ -75,13 +25,30 @@ const Filters = ({
 				className ?? ""
 			}`}
 		>
-			{types.map((type, index) => {
-				if (type === FilterType.SortBy) {
-					return renderSortBy(index);
-				} else if (type === FilterType.ViewAs) {
-					return renderViewAs(index);
-				}
-			})}
+			{shouldRenderSortBy && (
+				<div
+					className={`flex flex-row items-center mr-0 md:mb-0 ${
+						shouldRenderViewAs ? "mb-2 md:mr-6" : ""
+					}`}
+				>
+					Sort by
+					<select className="ml-2" value={sortBy} onChange={onChangeSortBy}>
+						<option value={SortBy.RecentlyTagged}>Recently tagged</option>
+						<option value={SortBy.RecentlyAdded}>Recently added</option>
+					</select>
+				</div>
+			)}
+
+			{shouldRenderViewAs && (
+				<div className="flex flex-row items-center mr-0 md:mb-0">
+					View as
+					<select className="ml-2" value={viewAs} onChange={onChangeViewAs}>
+						<option value={ViewAs.Card}>Cards</option>
+						<option value={ViewAs.Compact}>Compact</option>
+						<option value={ViewAs.List}>List</option>
+					</select>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/web/components/Footer.tsx
+++ b/web/components/Footer.tsx
@@ -19,8 +19,12 @@ const Footer = () => (
 			. We welcome community contributors.
 		</div>
 		<div>
-			<a href="https://forms.gle/7AU4e5JAd9XpRvBh8" target="_blank">
-				Share your feedback <i className="material-icons text-sm">launch</i>
+			<a
+				href="https://github.com/dgurns/trad-archive/discussions"
+				target="_blank"
+			>
+				Share feedback or report a bug{" "}
+				<i className="material-icons text-sm">launch</i>
 			</a>
 		</div>
 	</div>

--- a/web/components/Layout.tsx
+++ b/web/components/Layout.tsx
@@ -42,7 +42,11 @@ const Layout = ({ children, pageTitle }: Props) => {
 			</div>
 
 			{/* Add header to the DOM after child content so its modals overlay */}
-			<div className="fixed top-0 right-0 left-0" ref={fixedHeaderRef}>
+			<div
+				className="fixed top-0 right-0 left-0"
+				ref={fixedHeaderRef}
+				id="header"
+			>
 				{shouldShowPreviewWarning && (
 					<div className="flex flex-row items-center justify-center py-1 px-4 bg-black text-white text-sm text-center">
 						This is a preview version of the site with fake data.

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -59,7 +59,6 @@ const ViewEntity = ({ entity, className }: Props) => {
 
 	const headerOffset =
 		window.document.getElementById("header")?.offsetHeight ?? 0;
-	const metadataTopClass = `top-[${headerOffset}px]`;
 
 	return (
 		<div className={`flex flex-1 flex-col mb-8 ${className ?? ""}`}>
@@ -110,7 +109,8 @@ const ViewEntity = ({ entity, className }: Props) => {
 			<div
 				className={`${
 					metadataInView ? "hidden" : "visible"
-				} fixed left-0 right-0 p-4 ${metadataTopClass} bg-gray-100 shadow-lg`}
+				} fixed left-0 right-0 p-4 bg-gray-100 shadow-lg`}
+				style={{ top: `${headerOffset}px` }}
 			>
 				{totalAudioItems > 0 && <Filters {...filtersProps} />}
 			</div>

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -58,7 +58,8 @@ const ViewEntity = ({ entity, className }: Props) => {
 	}, [total]);
 
 	const headerOffset =
-		window.document.getElementById("header")?.offsetHeight + 12 ?? 0;
+		window.document.getElementById("header")?.offsetHeight ?? 0;
+	const metadataTopClass = `top-[${headerOffset}px]`;
 
 	return (
 		<div className={`flex flex-1 flex-col mb-8 ${className ?? ""}`}>
@@ -91,9 +92,7 @@ const ViewEntity = ({ entity, className }: Props) => {
 					</div>
 				)}
 			</div>
-
 			{audioItemsLoading && <LoadingBlock />}
-
 			{totalAudioItems > 0 &&
 				audioItems.map((audioItem, index) => (
 					<AudioItem
@@ -103,7 +102,6 @@ const ViewEntity = ({ entity, className }: Props) => {
 						className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
 					/>
 				))}
-
 			{audioItemsError && (
 				<div className="text-red-600">Error fetching Audio Items</div>
 			)}
@@ -112,7 +110,7 @@ const ViewEntity = ({ entity, className }: Props) => {
 			<div
 				className={`${
 					metadataInView ? "hidden" : "visible"
-				} fixed top-0 left-0 right-0 p-4 pt-[${headerOffset}px] bg-gray-100 shadow-lg`}
+				} fixed left-0 right-0 p-4 ${metadataTopClass} bg-gray-100 shadow-lg`}
 			>
 				{totalAudioItems > 0 && <Filters {...filtersProps} />}
 			</div>

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+import { Entity, PerPage, ViewAs } from "types";
+import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
+import useFilters from "hooks/useFilters";
+import EntityService from "services/Entity";
+
+import LoadingBlock from "components/LoadingBlock";
+import Breadcrumb from "components/Breadcrumb";
+import AudioItem from "components/AudioItem";
+
+interface Props {
+	entity: Entity;
+	className?: string;
+}
+const ViewEntity = ({ entity, className }: Props) => {
+	const { name } = entity ?? {};
+
+	const [totalAudioItems, setTotalAudioItems] = useState<number | undefined>();
+
+	const { Filters, filtersProps, page, perPage, viewAs } = useFilters({
+		defaultPage: 1,
+		totalItems: totalAudioItems,
+		defaultPerPage: PerPage.Twenty,
+		defaultViewAs: ViewAs.Card,
+	});
+
+	const {
+		audioItems = [],
+		total,
+		query: { loading: audioItemsLoading, error: audioItemsError },
+	} = useAudioItemsTaggedWithEntity({
+		entity,
+		page,
+		perPage: perPage as number,
+	});
+	useEffect(() => {
+		if (typeof total === "number") {
+			setTotalAudioItems(total);
+		}
+	}, [total]);
+
+	return (
+		<div className={`flex flex-1 flex-col mb-8 ${className ?? ""}`}>
+			<Breadcrumb
+				items={[
+					{
+						label: EntityService.makeReadableNamePlural(entity),
+						href: EntityService.makeHrefForTopLevel(entity),
+					},
+					{ label: name },
+				]}
+				className="mb-2"
+			/>
+			<div className="flex flex-row mb-6">
+				<span className="text-gray-500">
+					{totalAudioItems ?? ""} Audio Items
+				</span>
+				<Link href={EntityService.makeHrefForAbout(entity)}>
+					<a className="ml-4">About</a>
+				</Link>
+				<Link href={EntityService.makeHrefForTags(entity)}>
+					<a className="ml-4">Tags</a>
+				</Link>
+			</div>
+
+			{!totalAudioItems && audioItemsLoading && <LoadingBlock />}
+
+			{totalAudioItems > 0 && (
+				<>
+					<Filters {...filtersProps} className="mb-6" />
+					{audioItemsLoading ? (
+						<LoadingBlock />
+					) : (
+						audioItems.map((audioItem, index) => (
+							<AudioItem
+								viewAs={viewAs}
+								audioItem={audioItem}
+								key={index}
+								className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
+							/>
+						))
+					)}
+				</>
+			)}
+
+			{audioItemsError && (
+				<div className="text-red-600">Error fetching Audio Items</div>
+			)}
+		</div>
+	);
+};
+
+export default ViewEntity;

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useMemo } from "react";
 import Link from "next/link";
+import { useInView } from "react-intersection-observer";
 
 import { Entity, PerPage, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
@@ -17,6 +18,10 @@ interface Props {
 const ViewEntity = ({ entity, className }: Props) => {
 	const { name } = entity ?? {};
 
+	const { ref: metadataRef, inView: metadataInView } = useInView({
+		initialInView: true,
+	});
+
 	const [totalAudioItems, setTotalAudioItems] = useState<number | undefined>();
 
 	const { Filters, filtersProps, page, perPage, viewAs } = useFilters({
@@ -25,6 +30,11 @@ const ViewEntity = ({ entity, className }: Props) => {
 		defaultPerPage: PerPage.Twenty,
 		defaultViewAs: ViewAs.Card,
 	});
+
+	// Scroll to the top after choosing a different page of results
+	useEffect(() => {
+		window.scrollTo({ top: 0, behavior: "smooth" });
+	}, [page]);
 
 	const {
 		audioItems = [],
@@ -41,53 +51,61 @@ const ViewEntity = ({ entity, className }: Props) => {
 		}
 	}, [total]);
 
+	const headerOffset =
+		window.document.getElementById("header")?.offsetHeight + 12 ?? 0;
+
 	return (
 		<div className={`flex flex-1 flex-col mb-8 ${className ?? ""}`}>
-			<Breadcrumb
-				items={[
-					{
-						label: EntityService.makeReadableNamePlural(entity),
-						href: EntityService.makeHrefForTopLevel(entity),
-					},
-					{ label: name },
-				]}
-				className="mb-2"
-			/>
-			<div className="flex flex-row mb-6">
-				<span className="text-gray-500">
-					{totalAudioItems ?? ""} Audio Items
-				</span>
-				<Link href={EntityService.makeHrefForAbout(entity)}>
-					<a className="ml-4">About</a>
-				</Link>
-				<Link href={EntityService.makeHrefForTags(entity)}>
-					<a className="ml-4">Tags</a>
-				</Link>
+			{/* Initial metadata at top of page */}
+			<div className="mb-6" ref={metadataRef}>
+				<Breadcrumb
+					items={[
+						{
+							label: EntityService.makeReadableNamePlural(entity),
+							href: EntityService.makeHrefForTopLevel(entity),
+						},
+						{ label: name },
+					]}
+					className="mb-2"
+				/>
+				<div className="flex flex-row mb-6">
+					<span className="text-gray-500">
+						{totalAudioItems ?? ""} Audio Items
+					</span>
+					<Link href={EntityService.makeHrefForAbout(entity)}>
+						<a className="ml-4">About</a>
+					</Link>
+					<Link href={EntityService.makeHrefForTags(entity)}>
+						<a className="ml-4">Tags</a>
+					</Link>
+				</div>
+				{totalAudioItems > 0 && <Filters {...filtersProps} />}
 			</div>
 
-			{!totalAudioItems && audioItemsLoading && <LoadingBlock />}
+			{audioItemsLoading && <LoadingBlock />}
 
-			{totalAudioItems > 0 && (
-				<>
-					<Filters {...filtersProps} className="mb-6" />
-					{audioItemsLoading ? (
-						<LoadingBlock />
-					) : (
-						audioItems.map((audioItem, index) => (
-							<AudioItem
-								viewAs={viewAs}
-								audioItem={audioItem}
-								key={index}
-								className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-							/>
-						))
-					)}
-				</>
-			)}
+			{totalAudioItems > 0 &&
+				audioItems.map((audioItem, index) => (
+					<AudioItem
+						viewAs={viewAs}
+						audioItem={audioItem}
+						key={index}
+						className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
+					/>
+				))}
 
 			{audioItemsError && (
 				<div className="text-red-600">Error fetching Audio Items</div>
 			)}
+
+			{/* Fixed overlay metadata when scrolling. Render after AudioItems so it takes z-index precedence */}
+			<div
+				className={`${
+					metadataInView ? "hidden" : "visible"
+				} fixed top-0 left-0 right-0 p-4 pt-[${headerOffset}px] bg-gray-100 shadow-lg`}
+			>
+				{totalAudioItems > 0 && <Filters {...filtersProps} />}
+			</div>
 		</div>
 	);
 };

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -76,7 +76,7 @@ const ViewEntity = ({ entity, className }: Props) => {
 				/>
 				<div className="flex flex-row mb-6">
 					<span className="text-gray-500">
-						{totalAudioItems ?? ""} Audio Items
+						{totalAudioItems ?? ""} Audio Item{totalAudioItems === 1 ? "" : "s"}
 					</span>
 					<Link href={EntityService.makeHrefForAbout(entity)}>
 						<a className="ml-4">About</a>

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useMemo } from "react";
+import { useEffect, useState, useRef } from "react";
 import Link from "next/link";
 import { useInView } from "react-intersection-observer";
 
@@ -30,11 +30,17 @@ const ViewEntity = ({ entity, className }: Props) => {
 		defaultPerPage: PerPage.Twenty,
 		defaultViewAs: ViewAs.Card,
 	});
+	const filtersRef = useRef<HTMLDivElement>(null);
 
 	// Scroll to the top after choosing a different page of results
 	useEffect(() => {
-		window.scrollTo({ top: 0, behavior: "smooth" });
-	}, [page]);
+		if (filtersRef.current) {
+			filtersRef.current.scrollIntoView({
+				behavior: "smooth",
+				block: "end",
+			});
+		}
+	}, [page, filtersRef]);
 
 	const {
 		audioItems = [],
@@ -79,7 +85,11 @@ const ViewEntity = ({ entity, className }: Props) => {
 						<a className="ml-4">Tags</a>
 					</Link>
 				</div>
-				{totalAudioItems > 0 && <Filters {...filtersProps} />}
+				{totalAudioItems > 0 && (
+					<div ref={filtersRef}>
+						<Filters {...filtersProps} />
+					</div>
+				)}
 			</div>
 
 			{audioItemsLoading && <LoadingBlock />}

--- a/web/hooks/useAudioItem.ts
+++ b/web/hooks/useAudioItem.ts
@@ -26,9 +26,14 @@ interface QueryVariables {
 interface HookArgs {
 	slug?: string;
 	queryOptions?: LazyQueryHookOptions<QueryData, QueryVariables>;
+	skip?: boolean;
 }
 
-const useAudioItem = ({ slug, queryOptions = {} }: HookArgs = {}): [
+const useAudioItem = ({
+	slug,
+	queryOptions = {},
+	skip = false,
+}: HookArgs = {}): [
 	AudioItem | undefined,
 	LazyQueryResult<QueryData, QueryVariables>
 ] => {
@@ -39,6 +44,9 @@ const useAudioItem = ({ slug, queryOptions = {} }: HookArgs = {}): [
 	const { data } = audioItemQuery;
 
 	useEffect(() => {
+		if (skip) {
+			return;
+		}
 		if (slug) {
 			getAudioItem({
 				variables: {
@@ -46,7 +54,7 @@ const useAudioItem = ({ slug, queryOptions = {} }: HookArgs = {}): [
 				},
 			});
 		}
-	}, [getAudioItem, slug]);
+	}, [getAudioItem, slug, skip]);
 
 	const audioItem = data?.audioItem;
 

--- a/web/hooks/useAudioItemsTaggedWithEntity.ts
+++ b/web/hooks/useAudioItemsTaggedWithEntity.ts
@@ -1,24 +1,24 @@
-import { useEffect, useCallback, useState } from "react";
-import {
-	useLazyQuery,
-	gql,
-	LazyQueryResult,
-	LazyQueryHookOptions,
-} from "@apollo/client";
+import { useQuery, gql, QueryResult, QueryHookOptions } from "@apollo/client";
 import { Entity, EntityType, AudioItem } from "types";
 import { EntityFragments } from "fragments";
 
 export const AUDIO_ITEMS_TAGGED_WITH_ENTITY_QUERY = gql`
 	query AudioItemsTaggedWithEntity($input: AudioItemsTaggedWithEntityInput!) {
 		audioItemsTaggedWithEntity(input: $input) {
-			...AudioItem
+			audioItems {
+				...AudioItem
+			}
+			total
 		}
 	}
 	${EntityFragments.audioItem}
 `;
 
 interface QueryData {
-	audioItemsTaggedWithEntity?: AudioItem[];
+	audioItemsTaggedWithEntity?: {
+		audioItems: AudioItem[];
+		total: number;
+	};
 }
 interface QueryVariables {
 	input: {
@@ -30,70 +30,46 @@ interface QueryVariables {
 }
 interface HookArgs {
 	entity?: Entity;
-	resultsPerPage?: number;
-	queryOptions?: LazyQueryHookOptions<QueryData, QueryVariables>;
+	page?: number;
+	perPage?: number;
+	queryOptions?: QueryHookOptions<QueryData, QueryVariables>;
+}
+interface HookReturnValue {
+	audioItems: AudioItem[] | undefined;
+	total: number | undefined;
+	query: QueryResult<QueryData, QueryVariables>;
 }
 
 const useAudioItemsTaggedWithEntity = ({
 	entity,
-	resultsPerPage = 10,
+	page = 1,
+	perPage = 10,
 	queryOptions = {},
-}: HookArgs): [
-	AudioItem[] | undefined,
-	LazyQueryResult<QueryData, QueryVariables>,
-	() => void
-] => {
-	const [skip, setSkip] = useState(0);
-	const [audioItems, setAudioItems] = useState<AudioItem[] | undefined>();
-
-	const [makeQuery, query] = useLazyQuery<QueryData, QueryVariables>(
+}: HookArgs): HookReturnValue => {
+	const query = useQuery<QueryData, QueryVariables>(
 		AUDIO_ITEMS_TAGGED_WITH_ENTITY_QUERY,
 		{
-			notifyOnNetworkStatusChange: true,
+			variables: {
+				input: {
+					entityType: entity?.entityType,
+					entityId: entity?.id,
+					skip: (page - 1) * perPage,
+					take: perPage,
+				},
+			},
+			skip: !entity,
 			...queryOptions,
 		}
 	);
-	const { data, fetchMore } = query;
-	useEffect(() => {
-		// Avoid bug with Apollo Client where it makes an extra network request
-		// with original variables after `fetchMore` is called, thus leading to
-		// `data` briefly being `undefined`.
-		// https://github.com/apollographql/apollo-client/issues/6916
-		if (data?.audioItemsTaggedWithEntity) {
-			setAudioItems(data.audioItemsTaggedWithEntity);
-		}
-	}, [data]);
+	const { data } = query;
+	const audioItems = data?.audioItemsTaggedWithEntity?.audioItems;
+	const total = data?.audioItemsTaggedWithEntity?.total;
 
-	useEffect(() => {
-		if (entity) {
-			makeQuery({
-				variables: {
-					input: {
-						entityType: entity.entityType,
-						entityId: entity.id,
-						take: resultsPerPage + skip,
-					},
-				},
-			});
-		}
-	}, [makeQuery, entity, skip, resultsPerPage]);
-
-	const fetchNextPage = useCallback(async () => {
-		const numToSkip = audioItems?.length ?? 0;
-		await fetchMore({
-			variables: {
-				input: {
-					entityType: entity.entityType,
-					entityId: entity.id,
-					take: resultsPerPage,
-					skip: numToSkip,
-				},
-			},
-		});
-		setSkip(numToSkip);
-	}, [fetchMore, resultsPerPage, entity, audioItems]);
-
-	return [audioItems, query, fetchNextPage];
+	return {
+		audioItems,
+		total,
+		query,
+	};
 };
 
 export default useAudioItemsTaggedWithEntity;

--- a/web/hooks/useFilters.ts
+++ b/web/hooks/useFilters.ts
@@ -1,11 +1,11 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
 import { PerPage, SortBy, ViewAs } from "types";
 
 import Filters, { Props as FiltersProps } from "components/Filters";
 
 interface Args {
 	totalItems?: number;
-	defaultPage?: number;
+	defaultPage?: number; // Starts at 1
 	defaultPerPage?: PerPage;
 	defaultSortBy?: SortBy;
 	defaultViewAs?: ViewAs;
@@ -33,6 +33,11 @@ const useFilters = ({
 	const [perPage, setPerPage] = useState(defaultPerPage);
 	const [sortBy, setSortBy] = useState(defaultSortBy);
 	const [viewAs, setViewAs] = useState(defaultViewAs);
+
+	// Whenever perPage value changes, reset page to 1
+	useEffect(() => {
+		setPage(1);
+	}, [perPage]);
 
 	const onChangePage = useCallback(
 		(event: React.ChangeEvent<HTMLSelectElement>) =>

--- a/web/hooks/useFilters.ts
+++ b/web/hooks/useFilters.ts
@@ -1,10 +1,9 @@
 import React, { useState, useCallback, useMemo } from "react";
-import { FilterType, SortBy, ViewAs } from "types";
+import { SortBy, ViewAs } from "types";
 
 import Filters, { Props as FiltersProps } from "components/Filters";
 
 interface Args {
-	types?: Array<FilterType>;
 	defaultSortBy?: SortBy;
 	defaultViewAs?: ViewAs;
 }
@@ -16,12 +15,11 @@ interface ReturnValue {
 }
 
 // useFilters takes default values for sortBy and viewAs and returns the Filters
-// component along with props to pass to it, plus the output sortBy and
-// viewAs.
+// component along with props to pass to it, plus the current sortBy and
+// viewAs values.
 const useFilters = ({
-	types = [],
-	defaultSortBy = SortBy.RecentlyTagged,
-	defaultViewAs = ViewAs.Card,
+	defaultSortBy,
+	defaultViewAs,
 }: Args = {}): ReturnValue => {
 	const [sortBy, setSortBy] = useState(defaultSortBy);
 	const [viewAs, setViewAs] = useState(defaultViewAs);
@@ -39,13 +37,12 @@ const useFilters = ({
 
 	const filtersProps = useMemo(
 		() => ({
-			types,
 			sortBy,
 			onChangeSortBy,
 			viewAs,
 			onChangeViewAs,
 		}),
-		[types, sortBy, onChangeSortBy, viewAs, onChangeViewAs]
+		[sortBy, onChangeSortBy, viewAs, onChangeViewAs]
 	);
 
 	return { Filters, filtersProps, sortBy, viewAs };

--- a/web/hooks/useFilters.ts
+++ b/web/hooks/useFilters.ts
@@ -1,15 +1,20 @@
 import React, { useState, useCallback, useMemo } from "react";
-import { SortBy, ViewAs } from "types";
+import { PerPage, SortBy, ViewAs } from "types";
 
 import Filters, { Props as FiltersProps } from "components/Filters";
 
 interface Args {
+	totalItems?: number;
+	defaultPage?: number;
+	defaultPerPage?: PerPage;
 	defaultSortBy?: SortBy;
 	defaultViewAs?: ViewAs;
 }
 interface ReturnValue {
 	Filters: (props: FiltersProps) => React.ReactElement;
 	filtersProps: FiltersProps;
+	page?: number;
+	perPage?: PerPage;
 	sortBy?: SortBy;
 	viewAs?: ViewAs;
 }
@@ -18,12 +23,27 @@ interface ReturnValue {
 // component along with props to pass to it, plus the current sortBy and
 // viewAs values.
 const useFilters = ({
+	totalItems,
+	defaultPage,
+	defaultPerPage,
 	defaultSortBy,
 	defaultViewAs,
 }: Args = {}): ReturnValue => {
+	const [page, setPage] = useState(defaultPage);
+	const [perPage, setPerPage] = useState(defaultPerPage);
 	const [sortBy, setSortBy] = useState(defaultSortBy);
 	const [viewAs, setViewAs] = useState(defaultViewAs);
 
+	const onChangePage = useCallback(
+		(event: React.ChangeEvent<HTMLSelectElement>) =>
+			setPage(parseInt(event.target.value)),
+		[]
+	);
+	const onChangePerPage = useCallback(
+		(event: React.ChangeEvent<HTMLSelectElement>) =>
+			setPerPage(parseInt(event.target.value)),
+		[]
+	);
 	const onChangeSortBy = useCallback(
 		(event: React.ChangeEvent<HTMLSelectElement>) =>
 			setSortBy(event.target.value as SortBy),
@@ -37,15 +57,30 @@ const useFilters = ({
 
 	const filtersProps = useMemo(
 		() => ({
+			totalItems,
+			page,
+			onChangePage,
+			perPage,
+			onChangePerPage,
 			sortBy,
 			onChangeSortBy,
 			viewAs,
 			onChangeViewAs,
 		}),
-		[sortBy, onChangeSortBy, viewAs, onChangeViewAs]
+		[
+			totalItems,
+			page,
+			onChangePage,
+			perPage,
+			onChangePerPage,
+			sortBy,
+			onChangeSortBy,
+			viewAs,
+			onChangeViewAs,
+		]
 	);
 
-	return { Filters, filtersProps, sortBy, viewAs };
+	return { Filters, filtersProps, page, perPage, sortBy, viewAs };
 };
 
 export default useFilters;

--- a/web/hooks/useSavedItemsForUser.ts
+++ b/web/hooks/useSavedItemsForUser.ts
@@ -24,7 +24,8 @@ const useSavedItemsForUser = (): [
 	const [currentUser] = useCurrentUser();
 
 	const [makeQuery, query] = useLazyQuery<QueryData, {}>(
-		SAVED_ITEMS_FOR_USER_QUERY
+		SAVED_ITEMS_FOR_USER_QUERY,
+		{ fetchPolicy: "cache-first" }
 	);
 
 	useEffect(() => {

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-hotkeys-hook": "^3.3.1",
+    "react-intersection-observer": "^8.33.1",
     "tailwindcss": "^2.2.16"
   },
   "devDependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -9,19 +9,19 @@
   },
   "dependencies": {
     "@apollo/client": "^3.4.16",
-    "@tailwindcss/forms": "^0.2.1",
-    "autoprefixer": "^10.1.0",
+    "@tailwindcss/forms": "^0.4.0",
+    "autoprefixer": "^10.4.2",
     "class-validator": "^0.12.2",
     "date-fns": "^2.16.1",
     "graphql": "^15.4.0",
     "lodash": "^4.17.20",
     "next": "^12.0.4",
-    "postcss": "^8.2.15",
+    "postcss": "^8.4.6",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "react-hotkeys-hook": "^3.3.1",
     "react-intersection-observer": "^8.33.1",
-    "tailwindcss": "^2.2.16"
+    "tailwindcss": "^3.0.19"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.168",

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -26,7 +26,6 @@ const ViewCollectionBySlug = () => {
 	}>(COLLECTION_QUERY, {
 		variables: { slug },
 		skip: !slug,
-		fetchPolicy: "cache-and-network",
 	});
 	const { collection } = collectionData ?? {};
 

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Collection, FilterType, ViewAs } from "types";
+import { Collection, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -48,7 +48,7 @@ const ViewCollectionBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: collection });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const aboutMarkup = useMemo(

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -1,23 +1,14 @@
-import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Collection, PerPage, ViewAs } from "types";
-import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
-import useFilters from "hooks/useFilters";
-import TagService from "services/Tag";
+import { Collection } from "types";
 
 import Layout from "components/Layout";
-import Breadcrumb from "components/Breadcrumb";
 import LoadingBlock from "components/LoadingBlock";
-import AudioItem from "components/AudioItem";
-import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
-import AddTagButton from "components/AddTagButton";
-import EditTagsButton from "components/EditTagsButton";
+import ViewEntity from "components/ViewEntity";
 
-const COLLECTION_QUERY = gql`
+export const COLLECTION_QUERY = gql`
 	query Collection($slug: String!) {
 		collection(slug: $slug) {
 			...Collection
@@ -38,88 +29,6 @@ const ViewCollectionBySlug = () => {
 		fetchPolicy: "cache-and-network",
 	});
 	const { collection } = collectionData ?? {};
-	const { name, aliases, description, tags, itmaAtomSlug } = collection ?? {};
-	const sortedTags = TagService.sort(tags);
-
-	const [totalAudioItems, setTotalAudioItems] = useState<number | undefined>();
-
-	const { Filters, filtersProps, page, perPage, viewAs } = useFilters({
-		defaultPage: 1,
-		totalItems: totalAudioItems,
-		defaultPerPage: PerPage.Twenty,
-		defaultViewAs: ViewAs.Card,
-	});
-
-	const {
-		audioItems = [],
-		total,
-		query: { loading: audioItemsLoading, error: audioItemsError },
-	} = useAudioItemsTaggedWithEntity({
-		entity: collection,
-		page,
-		perPage: perPage as number,
-	});
-	useEffect(() => {
-		if (typeof total === "number") {
-			setTotalAudioItems(total);
-		}
-	}, [total]);
-
-	const aboutMarkup = useMemo(
-		() => (
-			<>
-				{itmaAtomSlug && (
-					<div className="mb-4">
-						<div className="italic text-gray-500">
-							This was sourced from ITMA's AtoM archive
-						</div>
-						<a
-							href={`https://itma-atom.arkivum.net/index.php/${itmaAtomSlug}`}
-							target="_blank"
-						>
-							View on AtoM <i className="material-icons text-sm">launch</i>
-						</a>
-					</div>
-				)}
-				{description && (
-					<div className="mb-4">
-						Description:
-						<br />
-						<span className="text-gray-500">{description}</span>
-					</div>
-				)}
-				{aliases && (
-					<div className="mb-4">
-						Aliases:
-						<br />
-						<span className="text-gray-500">{aliases}</span>
-					</div>
-				)}
-				<Link href={`/entities/collections/${slug}/edit`}>Edit</Link>
-			</>
-		),
-		[aliases, description, slug, itmaAtomSlug]
-	);
-
-	const tagsMarkup = useMemo(
-		() => (
-			<>
-				{sortedTags.map((tag, index) => (
-					<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
-				))}
-				<div>
-					<AddTagButton entity={collection} />
-					{sortedTags.length > 0 && (
-						<>
-							<span className="text-gray-500 px-2">/</span>
-							<EditTagsButton entity={collection} />
-						</>
-					)}
-				</div>
-			</>
-		),
-		[sortedTags, collection]
-	);
 
 	let statusMessage;
 	if (!collectionData && !collectionError) {
@@ -133,53 +42,8 @@ const ViewCollectionBySlug = () => {
 	}
 
 	return (
-		<Layout pageTitle={`Trad Archive - ${name}`}>
-			<div className="flex flex-col md:flex-row">
-				<div className="flex flex-1 flex-col mb-8">
-					<Breadcrumb
-						items={[
-							{ label: "Collections", href: "/entities/collections" },
-							{ label: name },
-						]}
-						className="mb-2"
-					/>
-					<div className="flex flex-row mb-6">
-						<span className="text-gray-500">
-							{totalAudioItems ?? ""} Audio Items
-						</span>
-						<Link href={`/entities/collections/${slug}/about`}>
-							<a className="ml-4">About</a>
-						</Link>
-						<Link href={`/entities/collections/${slug}/tags`}>
-							<a className="ml-4">Tags</a>
-						</Link>
-					</div>
-
-					{!totalAudioItems && audioItemsLoading && <LoadingBlock />}
-
-					{totalAudioItems > 0 && (
-						<>
-							<Filters {...filtersProps} className="mb-6" />
-							{audioItemsLoading ? (
-								<LoadingBlock />
-							) : (
-								audioItems.map((audioItem, index) => (
-									<AudioItem
-										viewAs={viewAs}
-										audioItem={audioItem}
-										key={index}
-										className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-									/>
-								))
-							)}
-						</>
-					)}
-
-					{audioItemsError && (
-						<div className="text-red-600">Error fetching Audio Items</div>
-					)}
-				</div>
-			</div>
+		<Layout pageTitle={`Trad Archive - ${collection.name}`}>
+			<ViewEntity entity={collection} />
 		</Layout>
 	);
 };

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -41,7 +41,7 @@ const ViewCollectionBySlug = () => {
 	const { name, aliases, description, tags, itmaAtomSlug } = collection ?? {};
 	const sortedTags = TagService.sort(tags);
 
-	const [totalAudioItems, setTotalAudioItems] = useState<number>();
+	const [totalAudioItems, setTotalAudioItems] = useState<number | undefined>();
 
 	const { Filters, filtersProps, page, perPage, viewAs } = useFilters({
 		defaultPage: 1,
@@ -132,9 +132,6 @@ const ViewCollectionBySlug = () => {
 		return <Layout>{statusMessage}</Layout>;
 	}
 
-	const noAudioItemsFound =
-		!audioItemsLoading && !audioItemsError && audioItems.length === 0;
-
 	return (
 		<Layout pageTitle={`Trad Archive - ${name}`}>
 			<div className="flex flex-col md:flex-row">
@@ -144,10 +141,19 @@ const ViewCollectionBySlug = () => {
 							{ label: "Collections", href: "/entities/collections" },
 							{ label: name },
 						]}
-						className="mb-6"
+						className="mb-2"
 					/>
-
-					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
+					<div className="flex flex-row mb-6">
+						<span className="text-gray-500">
+							{totalAudioItems ?? ""} Audio Items
+						</span>
+						<Link href={`/entities/collections/${slug}/about`}>
+							<a className="ml-4">About</a>
+						</Link>
+						<Link href={`/entities/collections/${slug}/tags`}>
+							<a className="ml-4">Tags</a>
+						</Link>
+					</div>
 
 					{!totalAudioItems && audioItemsLoading && <LoadingBlock />}
 
@@ -169,21 +175,9 @@ const ViewCollectionBySlug = () => {
 						</>
 					)}
 
-					{noAudioItemsFound && (
-						<div className="text-gray-500">
-							No Audio Items tagged with this yet
-						</div>
-					)}
 					{audioItemsError && (
 						<div className="text-red-600">Error fetching Audio Items</div>
 					)}
-				</div>
-
-				<div className="hidden md:flex flex-col items-start md:ml-8 md:pl-8 md:w-1/4 md:border-l md:border-gray-300">
-					<h3 className="mb-4">About</h3>
-					{aboutMarkup}
-					<h3 className="mt-8 mb-4">Tags</h3>
-					{tagsMarkup}
 				</div>
 			</div>
 		</Layout>

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -10,6 +10,7 @@ import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
 
 import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
 import LoadingBlock from "components/LoadingBlock";
 import AudioItem from "components/AudioItem";
 import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
@@ -125,15 +126,13 @@ const ViewCollectionBySlug = () => {
 		<Layout pageTitle={`Trad Archive - ${name}`}>
 			<div className="flex flex-col md:flex-row">
 				<div className="flex flex-1 flex-col mb-8">
-					<div className="flex flex-row items-center mb-1">
-						<Link href="/entities/collections">
-							<a className="mr-1">Collections</a>
-						</Link>
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{name}</h1>
+					<Breadcrumb
+						items={[
+							{ label: "Collections", href: "/entities/collections" },
+							{ label: name },
+						]}
+						className="mb-6"
+					/>
 
 					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
 

--- a/web/pages/entities/collections/[slug].tsx
+++ b/web/pages/entities/collections/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Collection, ViewAs } from "types";
+import { Collection, PerPage, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -48,6 +48,9 @@ const ViewCollectionBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: collection });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
+		defaultPage: 0,
+		totalItems: 112,
+		defaultPerPage: PerPage.Ten,
 		defaultViewAs: ViewAs.Card,
 	});
 

--- a/web/pages/entities/collections/[slug]/about.tsx
+++ b/web/pages/entities/collections/[slug]/about.tsx
@@ -1,0 +1,108 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+import Link from "next/link";
+
+import { Collection } from "types";
+import { API_URL } from "apolloClient";
+
+import Layout from "components/Layout";
+import { COLLECTION_QUERY } from "pages/entities/collections/[slug]";
+import Breadcrumb from "components/Breadcrumb";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let collection: Collection | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			collection: Collection;
+		}>({
+			query: COLLECTION_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		collection = data.collection;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			collection,
+		},
+	};
+}
+
+interface Props {
+	collection: Collection;
+}
+
+const CollectionAbout = ({ collection }: Props) => {
+	if (!collection) {
+		return <Layout>Error fetching Collection</Layout>;
+	}
+
+	const { name, slug, itmaAtomSlug, description, aliases } = collection;
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - About`}>
+			<Breadcrumb
+				items={[
+					{ label: "Collections", href: "/entities/collections" },
+					{ label: name, href: `/entities/collections/${slug}` },
+					{ label: "About" },
+				]}
+				className="mb-6"
+			/>
+
+			{itmaAtomSlug && (
+				<div className="mb-4">
+					<div className="italic text-gray-500">
+						This was sourced from ITMA's AtoM archive
+					</div>
+					<a
+						href={`https://itma-atom.arkivum.net/index.php/${itmaAtomSlug}`}
+						target="_blank"
+					>
+						View on AtoM <i className="material-icons text-sm">launch</i>
+					</a>
+				</div>
+			)}
+			{description && (
+				<div className="mb-4">
+					Description:
+					<br />
+					<span className="text-gray-500">{description}</span>
+				</div>
+			)}
+			{aliases && (
+				<div className="mb-4">
+					Aliases:
+					<br />
+					<span className="text-gray-500">{aliases}</span>
+				</div>
+			)}
+			<Link href={`/entities/collections/${slug}/edit`}>Edit</Link>
+		</Layout>
+	);
+};
+
+export default CollectionAbout;

--- a/web/pages/entities/collections/[slug]/edit.tsx
+++ b/web/pages/entities/collections/[slug]/edit.tsx
@@ -18,7 +18,7 @@ const COLLECTION_QUERY = gql`
 	${EntityFragments.collection}
 `;
 
-const EditCollection = () => {
+const CollectionEdit = () => {
 	const router = useRouter();
 	const { slug } = router.query;
 
@@ -28,7 +28,7 @@ const EditCollection = () => {
 	});
 
 	const onEditSuccess = (collection: Collection) => {
-		router.push(`/entities/collections/${collection.slug}`);
+		router.push(`/entities/collections/${collection.slug}/about`);
 	};
 
 	let statusMessage;
@@ -59,4 +59,4 @@ const EditCollection = () => {
 	);
 };
 
-export default EditCollection;
+export default CollectionEdit;

--- a/web/pages/entities/collections/[slug]/tags.tsx
+++ b/web/pages/entities/collections/[slug]/tags.tsx
@@ -1,0 +1,102 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+
+import { Collection } from "types";
+import TagService from "services/Tag";
+import { API_URL } from "apolloClient";
+import { COLLECTION_QUERY } from "pages/entities/collections/[slug]";
+
+import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
+import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import AddTagButton from "components/AddTagButton";
+import EditTagsButton from "components/EditTagsButton";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let collection: Collection | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			collection: Collection;
+		}>({
+			query: COLLECTION_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		collection = data.collection;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			collection,
+		},
+	};
+}
+
+interface Props {
+	collection: Collection;
+}
+
+const CollectionTags = ({ collection }: Props) => {
+	if (!collection) {
+		return <Layout>Error fetching Collection</Layout>;
+	}
+
+	const { name, slug, tags } = collection;
+	const sortedTags = TagService.sort(tags);
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - Tags`}>
+			<Breadcrumb
+				items={[
+					{ label: "Collections", href: "/entities/collections" },
+					{ label: name, href: `/entities/collections/${slug}` },
+					{ label: "Tags" },
+				]}
+				className="mb-6"
+			/>
+
+			{sortedTags.map((tag, index) => (
+				<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
+			))}
+			<div>
+				<AddTagButton
+					entity={collection}
+					onSuccess={() => window.location.reload()}
+				/>
+				{sortedTags.length > 0 && (
+					<>
+						<span className="text-gray-500 px-2">/</span>
+						<EditTagsButton
+							entity={collection}
+							onSuccess={() => window.location.reload()}
+						/>
+					</>
+				)}
+			</div>
+		</Layout>
+	);
+};
+
+export default CollectionTags;

--- a/web/pages/entities/instruments/[slug].tsx
+++ b/web/pages/entities/instruments/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Instrument, FilterType, ViewAs } from "types";
+import { Instrument, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -47,7 +47,7 @@ const ViewInstrumentBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: instrument });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const aboutMarkup = useMemo(

--- a/web/pages/entities/instruments/[slug].tsx
+++ b/web/pages/entities/instruments/[slug].tsx
@@ -1,22 +1,14 @@
-import { useMemo } from "react";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Instrument, ViewAs } from "types";
-import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
-import useFilters from "hooks/useFilters";
-import TagService from "services/Tag";
+import { Instrument } from "types";
 
 import Layout from "components/Layout";
 import LoadingBlock from "components/LoadingBlock";
-import AudioItem from "components/AudioItem";
-import AddTagButton from "components/AddTagButton";
-import EditTagsButton from "components/EditTagsButton";
-import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import ViewEntity from "components/ViewEntity";
 
-const INSTRUMENT_QUERY = gql`
+export const INSTRUMENT_QUERY = gql`
 	query Instrument($slug: String!) {
 		instrument(slug: $slug) {
 			...Instrument
@@ -34,64 +26,8 @@ const ViewInstrumentBySlug = () => {
 	}>(INSTRUMENT_QUERY, {
 		variables: { slug },
 		skip: !slug,
-		fetchPolicy: "cache-and-network",
 	});
 	const { instrument } = instrumentData ?? {};
-	const { name, aliases, description, tags } = instrument ?? {};
-	const sortedTags = TagService.sort(tags);
-
-	const [
-		audioItems = [],
-		{ loading: audioItemsLoading, error: audioItemsError },
-		fetchNextPageOfAudioItems,
-	] = useAudioItemsTaggedWithEntity({ entity: instrument });
-
-	const { Filters, filtersProps, viewAs } = useFilters({
-		defaultViewAs: ViewAs.Card,
-	});
-
-	const aboutMarkup = useMemo(
-		() => (
-			<>
-				{description && (
-					<div className="mb-4">
-						Description:
-						<br />
-						<span className="text-gray-500">{description}</span>
-					</div>
-				)}
-				{aliases && (
-					<div className="mb-4">
-						Aliases:
-						<br />
-						<span className="text-gray-500">{aliases}</span>
-					</div>
-				)}
-				<Link href={`/entities/instruments/${slug}/edit`}>Edit</Link>
-			</>
-		),
-		[aliases, description, slug]
-	);
-
-	const tagsMarkup = useMemo(
-		() => (
-			<>
-				{sortedTags.map((tag, index) => (
-					<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
-				))}
-				<div>
-					<AddTagButton entity={instrument} />
-					{sortedTags.length > 0 && (
-						<>
-							<span className="text-gray-500 px-2">/</span>
-							<EditTagsButton entity={instrument} />
-						</>
-					)}
-				</div>
-			</>
-		),
-		[sortedTags, instrument]
-	);
 
 	let statusMessage;
 	if (!instrumentData && !instrumentError) {
@@ -104,66 +40,9 @@ const ViewInstrumentBySlug = () => {
 		return <Layout>{statusMessage}</Layout>;
 	}
 
-	const shouldShowAudioItems = audioItems.length > 0;
-	const noAudioItemsFound =
-		!audioItemsLoading && !audioItemsError && audioItems.length === 0;
-
 	return (
-		<Layout pageTitle={`Trad Archive - ${name}`}>
-			<div className="flex flex-col md:flex-row">
-				<div className="flex flex-1 flex-col pb-8">
-					<div className="flex flex-row items-center mb-1">
-						<Link href="/entities/instruments">
-							<a className="mr-1">Instruments</a>
-						</Link>
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{name}</h1>
-
-					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
-
-					{shouldShowAudioItems && (
-						<>
-							<Filters {...filtersProps} className="mb-6" />
-
-							{audioItems.map((audioItem, index) => (
-								<AudioItem
-									viewAs={viewAs}
-									audioItem={audioItem}
-									key={index}
-									className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-								/>
-							))}
-							{!audioItemsLoading && (
-								<button
-									className="btn-text"
-									onClick={fetchNextPageOfAudioItems}
-								>
-									Load More
-								</button>
-							)}
-						</>
-					)}
-					{audioItemsLoading && <LoadingBlock />}
-					{noAudioItemsFound && (
-						<div className="text-gray-500">
-							No Audio Items tagged with this yet
-						</div>
-					)}
-					{audioItemsError && (
-						<div className="text-red-600">Error fetching Audio Items</div>
-					)}
-				</div>
-
-				<div className="hidden md:flex flex-col items-start md:ml-8 md:pl-8 md:w-1/4 md:border-l md:border-gray-300">
-					<h3 className="mb-4">About</h3>
-					{aboutMarkup}
-					<h3 className="mt-8 mb-4">Tags</h3>
-					{tagsMarkup}
-				</div>
-			</div>
+		<Layout pageTitle={`Trad Archive - ${instrument.name}`}>
+			<ViewEntity entity={instrument} />
 		</Layout>
 	);
 };

--- a/web/pages/entities/instruments/[slug]/about.tsx
+++ b/web/pages/entities/instruments/[slug]/about.tsx
@@ -1,0 +1,95 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+import Link from "next/link";
+
+import { Instrument } from "types";
+import { API_URL } from "apolloClient";
+
+import Layout from "components/Layout";
+import { INSTRUMENT_QUERY } from "pages/entities/instruments/[slug]";
+import Breadcrumb from "components/Breadcrumb";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let instrument: Instrument | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			instrument: Instrument;
+		}>({
+			query: INSTRUMENT_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		instrument = data.instrument;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			instrument,
+		},
+	};
+}
+
+interface Props {
+	instrument: Instrument;
+}
+
+const InstrumentAbout = ({ instrument }: Props) => {
+	if (!instrument) {
+		return <Layout>Error fetching Instrument</Layout>;
+	}
+
+	const { name, slug, description, aliases } = instrument;
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - About`}>
+			<Breadcrumb
+				items={[
+					{ label: "Instruments", href: "/entities/instruments" },
+					{ label: name, href: `/entities/instruments/${slug}` },
+					{ label: "About" },
+				]}
+				className="mb-6"
+			/>
+
+			{description && (
+				<div className="mb-4">
+					Description:
+					<br />
+					<span className="text-gray-500">{description}</span>
+				</div>
+			)}
+			{aliases && (
+				<div className="mb-4">
+					Aliases:
+					<br />
+					<span className="text-gray-500">{aliases}</span>
+				</div>
+			)}
+			<Link href={`/entities/instruments/${slug}/edit`}>Edit</Link>
+		</Layout>
+	);
+};
+
+export default InstrumentAbout;

--- a/web/pages/entities/instruments/[slug]/tags.tsx
+++ b/web/pages/entities/instruments/[slug]/tags.tsx
@@ -1,0 +1,102 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+
+import { Instrument } from "types";
+import TagService from "services/Tag";
+import { API_URL } from "apolloClient";
+import { INSTRUMENT_QUERY } from "pages/entities/instruments/[slug]";
+
+import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
+import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import AddTagButton from "components/AddTagButton";
+import EditTagsButton from "components/EditTagsButton";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let instrument: Instrument | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			instrument: Instrument;
+		}>({
+			query: INSTRUMENT_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		instrument = data.instrument;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			instrument,
+		},
+	};
+}
+
+interface Props {
+	instrument: Instrument;
+}
+
+const InstrumentTags = ({ instrument }: Props) => {
+	if (!instrument) {
+		return <Layout>Error fetching Instrument</Layout>;
+	}
+
+	const { name, slug, tags } = instrument;
+	const sortedTags = TagService.sort(tags);
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - Tags`}>
+			<Breadcrumb
+				items={[
+					{ label: "Instruments", href: "/entities/instruments" },
+					{ label: name, href: `/entities/instruments/${slug}` },
+					{ label: "Tags" },
+				]}
+				className="mb-6"
+			/>
+
+			{sortedTags.map((tag, index) => (
+				<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
+			))}
+			<div>
+				<AddTagButton
+					entity={instrument}
+					onSuccess={() => window.location.reload()}
+				/>
+				{sortedTags.length > 0 && (
+					<>
+						<span className="text-gray-500 px-2">/</span>
+						<EditTagsButton
+							entity={instrument}
+							onSuccess={() => window.location.reload()}
+						/>
+					</>
+				)}
+			</div>
+		</Layout>
+	);
+};
+
+export default InstrumentTags;

--- a/web/pages/entities/people/[slug].tsx
+++ b/web/pages/entities/people/[slug].tsx
@@ -1,22 +1,14 @@
-import { useMemo } from "react";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Person, ViewAs } from "types";
-import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
-import useFilters from "hooks/useFilters";
-import TagService from "services/Tag";
+import { Person } from "types";
 
 import Layout from "components/Layout";
 import LoadingBlock from "components/LoadingBlock";
-import AudioItem from "components/AudioItem";
-import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
-import AddTagButton from "components/AddTagButton";
-import EditTagsButton from "components/EditTagsButton";
+import ViewEntity from "components/ViewEntity";
 
-const PERSON_QUERY = gql`
+export const PERSON_QUERY = gql`
 	query Person($slug: String!) {
 		person(slug: $slug) {
 			...Person
@@ -29,87 +21,13 @@ const ViewPersonBySlug = () => {
 	const router = useRouter();
 	const { slug } = router.query;
 
-	const { data: personData, error: personError } = useQuery<{ person: Person }>(
-		PERSON_QUERY,
-		{
-			variables: { slug },
-			skip: !slug,
-			fetchPolicy: "cache-and-network",
-		}
-	);
-
-	const [
-		audioItems = [],
-		{ loading: audioItemsLoading, error: audioItemsError },
-		fetchNextPageOfAudioItems,
-	] = useAudioItemsTaggedWithEntity({ entity: personData?.person });
-
-	const { Filters, filtersProps, viewAs } = useFilters({
-		defaultViewAs: ViewAs.Card,
+	const { data: personData, error: personError } = useQuery<{
+		person: Person;
+	}>(PERSON_QUERY, {
+		variables: { slug },
+		skip: !slug,
 	});
-
 	const { person } = personData ?? {};
-	const { name, aliases, description, tags, verifiedUser } = person ?? {};
-	const sortedTags = TagService.sort(tags);
-
-	const shouldShowAudioItems = audioItems.length > 0;
-	const noAudioItemsFound =
-		!audioItemsLoading && !audioItemsError && audioItems.length === 0;
-
-	const aboutMarkup = useMemo(
-		() => (
-			<>
-				{verifiedUser && (
-					<div className="mb-4">
-						<div className="flex flex-row items-center">
-							<i className="material-icons text-base mr-2">verified</i>
-							Verified As User:
-						</div>
-						<Link href={`/users/${verifiedUser.id}`}>
-							{verifiedUser.username}
-						</Link>
-					</div>
-				)}
-
-				{aliases && (
-					<div className="mb-4">
-						Aliases:
-						<br />
-						<span className="text-gray-500">{aliases}</span>
-					</div>
-				)}
-				{description && (
-					<div className="mb-4">
-						Description:
-						<br />
-						<span className="text-gray-500">{description}</span>
-					</div>
-				)}
-				<Link href={`/entities/people/${slug}/edit`}>Edit</Link>
-			</>
-		),
-		[verifiedUser, aliases, description, slug]
-	);
-
-	const tagsMarkup = useMemo(
-		() => (
-			<>
-				{sortedTags.map((tag, index) => (
-					<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
-				))}
-				<div>
-					<AddTagButton entity={person} />
-					{sortedTags.length > 0 && (
-						<>
-							<span className="text-gray-500 px-2">/</span>
-							<EditTagsButton entity={person} />
-						</>
-					)}
-				</div>
-			</>
-		),
-		[sortedTags, person]
-	);
 
 	let statusMessage;
 	if (!personData && !personError) {
@@ -123,61 +41,8 @@ const ViewPersonBySlug = () => {
 	}
 
 	return (
-		<Layout pageTitle={`Trad Archive - ${name}`}>
-			<div className="flex flex-col md:flex-row">
-				<div className="flex flex-1 flex-col mb-8">
-					<div className="flex flex-row items-center mb-1">
-						<Link href="/entities/people">
-							<a className="mr-1">People</a>
-						</Link>
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{name}</h1>
-
-					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
-
-					{shouldShowAudioItems && (
-						<>
-							<Filters {...filtersProps} className="mb-6" />
-
-							{audioItems.map((audioItem, index) => (
-								<AudioItem
-									viewAs={viewAs}
-									audioItem={audioItem}
-									key={index}
-									className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-								/>
-							))}
-							{!audioItemsLoading && (
-								<button
-									className="btn-text"
-									onClick={fetchNextPageOfAudioItems}
-								>
-									Load More
-								</button>
-							)}
-						</>
-					)}
-					{audioItemsLoading && <LoadingBlock />}
-					{noAudioItemsFound && (
-						<div className="text-gray-500">
-							No Audio Items tagged with this yet
-						</div>
-					)}
-					{audioItemsError && (
-						<div className="text-red-600">Error fetching Audio Items</div>
-					)}
-				</div>
-
-				<div className="hidden md:flex flex-col items-start md:ml-8 md:pl-8 md:w-1/4 md:border-l md:border-gray-300">
-					<h3 className="mb-4">About</h3>
-					{aboutMarkup}
-					<h3 className="mt-8 mb-4">Tags</h3>
-					{tagsMarkup}
-				</div>
-			</div>
+		<Layout pageTitle={`Trad Archive - ${person.name}`}>
+			<ViewEntity entity={person} />
 		</Layout>
 	);
 };

--- a/web/pages/entities/people/[slug].tsx
+++ b/web/pages/entities/people/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Person, FilterType, ViewAs } from "types";
+import { Person, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -45,7 +45,7 @@ const ViewPersonBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: personData?.person });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const { person } = personData ?? {};

--- a/web/pages/entities/people/[slug]/about.tsx
+++ b/web/pages/entities/people/[slug]/about.tsx
@@ -1,0 +1,95 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+import Link from "next/link";
+
+import { Person } from "types";
+import { API_URL } from "apolloClient";
+
+import Layout from "components/Layout";
+import { PERSON_QUERY } from "pages/entities/people/[slug]";
+import Breadcrumb from "components/Breadcrumb";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let person: Person | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			person: Person;
+		}>({
+			query: PERSON_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		person = data.person;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			person,
+		},
+	};
+}
+
+interface Props {
+	person: Person;
+}
+
+const PersonAbout = ({ person }: Props) => {
+	if (!person) {
+		return <Layout>Error fetching Person</Layout>;
+	}
+
+	const { name, slug, description, aliases } = person;
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - About`}>
+			<Breadcrumb
+				items={[
+					{ label: "People", href: "/entities/people" },
+					{ label: name, href: `/entities/people/${slug}` },
+					{ label: "About" },
+				]}
+				className="mb-6"
+			/>
+
+			{description && (
+				<div className="mb-4">
+					Description:
+					<br />
+					<span className="text-gray-500">{description}</span>
+				</div>
+			)}
+			{aliases && (
+				<div className="mb-4">
+					Aliases:
+					<br />
+					<span className="text-gray-500">{aliases}</span>
+				</div>
+			)}
+			<Link href={`/entities/people/${slug}/edit`}>Edit</Link>
+		</Layout>
+	);
+};
+
+export default PersonAbout;

--- a/web/pages/entities/people/[slug]/tags.tsx
+++ b/web/pages/entities/people/[slug]/tags.tsx
@@ -1,0 +1,102 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+
+import { Person } from "types";
+import TagService from "services/Tag";
+import { API_URL } from "apolloClient";
+import { PERSON_QUERY } from "pages/entities/people/[slug]";
+
+import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
+import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import AddTagButton from "components/AddTagButton";
+import EditTagsButton from "components/EditTagsButton";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let person: Person | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			person: Person;
+		}>({
+			query: PERSON_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		person = data.person;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			person,
+		},
+	};
+}
+
+interface Props {
+	person: Person;
+}
+
+const PersonTags = ({ person }: Props) => {
+	if (!person) {
+		return <Layout>Error fetching Person</Layout>;
+	}
+
+	const { name, slug, tags } = person;
+	const sortedTags = TagService.sort(tags);
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - Tags`}>
+			<Breadcrumb
+				items={[
+					{ label: "People", href: "/entities/people" },
+					{ label: name, href: `/entities/people/${slug}` },
+					{ label: "Tags" },
+				]}
+				className="mb-6"
+			/>
+
+			{sortedTags.map((tag, index) => (
+				<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
+			))}
+			<div>
+				<AddTagButton
+					entity={person}
+					onSuccess={() => window.location.reload()}
+				/>
+				{sortedTags.length > 0 && (
+					<>
+						<span className="text-gray-500 px-2">/</span>
+						<EditTagsButton
+							entity={person}
+							onSuccess={() => window.location.reload()}
+						/>
+					</>
+				)}
+			</div>
+		</Layout>
+	);
+};
+
+export default PersonTags;

--- a/web/pages/entities/places/[slug].tsx
+++ b/web/pages/entities/places/[slug].tsx
@@ -1,22 +1,14 @@
-import { useMemo } from "react";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Place, ViewAs } from "types";
-import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
-import useFilters from "hooks/useFilters";
-import TagService from "services/Tag";
+import { Place } from "types";
 
 import Layout from "components/Layout";
 import LoadingBlock from "components/LoadingBlock";
-import AudioItem from "components/AudioItem";
-import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
-import AddTagButton from "components/AddTagButton";
-import EditTagsButton from "components/EditTagsButton";
+import ViewEntity from "components/ViewEntity";
 
-const PLACE_QUERY = gql`
+export const PLACE_QUERY = gql`
 	query Place($slug: String!) {
 		place(slug: $slug) {
 			...Place
@@ -29,86 +21,13 @@ const ViewPlaceBySlug = () => {
 	const router = useRouter();
 	const { slug } = router.query;
 
-	const { data: placeData, error: placeError } = useQuery<{ place: Place }>(
-		PLACE_QUERY,
-		{
-			variables: { slug },
-			skip: !slug,
-			fetchPolicy: "cache-and-network",
-		}
-	);
-	const { place } = placeData ?? {};
-	const { name, aliases, description, tags, latitude, longitude } = place ?? {};
-	const sortedTags = TagService.sort(tags);
-
-	const [
-		audioItems = [],
-		{ loading: audioItemsLoading, error: audioItemsError },
-		fetchNextPageOfAudioItems,
-	] = useAudioItemsTaggedWithEntity({ entity: place });
-
-	const { Filters, filtersProps, viewAs } = useFilters({
-		defaultViewAs: ViewAs.Card,
+	const { data: placeData, error: placeError } = useQuery<{
+		place: Place;
+	}>(PLACE_QUERY, {
+		variables: { slug },
+		skip: !slug,
 	});
-
-	const aboutMarkup = useMemo(
-		() => (
-			<>
-				{description && (
-					<div className="mb-4">
-						Description:
-						<br />
-						<span className="text-gray-500">{description}</span>
-					</div>
-				)}
-				{aliases && (
-					<div className="mb-4">
-						Aliases:
-						<br />
-						<span className="text-gray-500">{aliases}</span>
-					</div>
-				)}
-				{latitude && longitude && (
-					<div className="mb-4">
-						Latitude and Longitude:
-						<br />
-						<span className="text-gray-500">
-							{latitude},{longitude}
-						</span>
-						<br />
-						<a
-							href={`https://www.google.com/maps/@?api=1&map_action=map&zoom=12&center=${latitude},${longitude}`}
-							target="_blank"
-						>
-							View on Map
-						</a>
-					</div>
-				)}
-				<Link href={`/entities/places/${slug}/edit`}>Edit</Link>
-			</>
-		),
-		[aliases, description, slug, latitude, longitude]
-	);
-
-	const tagsMarkup = useMemo(
-		() => (
-			<>
-				{sortedTags.map((tag, index) => (
-					<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
-				))}
-				<div>
-					<AddTagButton entity={place} />
-					{sortedTags.length > 0 && (
-						<>
-							<span className="text-gray-500 px-2">/</span>
-							<EditTagsButton entity={place} />
-						</>
-					)}
-				</div>
-			</>
-		),
-		[sortedTags, place]
-	);
+	const { place } = placeData ?? {};
 
 	let statusMessage;
 	if (!placeData && !placeError) {
@@ -121,66 +40,9 @@ const ViewPlaceBySlug = () => {
 		return <Layout>{statusMessage}</Layout>;
 	}
 
-	const shouldShowAudioItems = audioItems.length > 0;
-	const noAudioItemsFound =
-		!audioItemsLoading && !audioItemsError && audioItems.length === 0;
-
 	return (
-		<Layout pageTitle={`Trad Archive - ${name}`}>
-			<div className="flex flex-col md:flex-row">
-				<div className="flex flex-1 flex-col mb-8">
-					<div className="flex flex-row items-center mb-1">
-						<Link href="/entities/places">
-							<a className="mr-1">Places</a>
-						</Link>
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{name}</h1>
-
-					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
-
-					{shouldShowAudioItems && (
-						<>
-							<Filters {...filtersProps} className="mb-6" />
-
-							{audioItems.map((audioItem, index) => (
-								<AudioItem
-									viewAs={viewAs}
-									audioItem={audioItem}
-									key={index}
-									className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-								/>
-							))}
-							{!audioItemsLoading && (
-								<button
-									className="btn-text"
-									onClick={fetchNextPageOfAudioItems}
-								>
-									Load More
-								</button>
-							)}
-						</>
-					)}
-					{audioItemsLoading && <LoadingBlock />}
-					{noAudioItemsFound && (
-						<div className="text-gray-500">
-							No Audio Items tagged with this yet
-						</div>
-					)}
-					{audioItemsError && (
-						<div className="text-red-600">Error fetching Audio Items</div>
-					)}
-				</div>
-
-				<div className="hidden md:flex flex-col items-start md:ml-8 md:pl-8 md:w-1/4 md:border-l md:border-gray-300">
-					<h3 className="mb-4">About</h3>
-					{aboutMarkup}
-					<h3 className="mt-8 mb-4">Tags</h3>
-					{tagsMarkup}
-				</div>
-			</div>
+		<Layout pageTitle={`Trad Archive - ${place.name}`}>
+			<ViewEntity entity={place} />
 		</Layout>
 	);
 };

--- a/web/pages/entities/places/[slug].tsx
+++ b/web/pages/entities/places/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Place, FilterType, ViewAs } from "types";
+import { Place, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -48,7 +48,7 @@ const ViewPlaceBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: place });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const aboutMarkup = useMemo(

--- a/web/pages/entities/places/[slug]/about.tsx
+++ b/web/pages/entities/places/[slug]/about.tsx
@@ -1,0 +1,95 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+import Link from "next/link";
+
+import { Place } from "types";
+import { API_URL } from "apolloClient";
+
+import Layout from "components/Layout";
+import { PLACE_QUERY } from "pages/entities/places/[slug]";
+import Breadcrumb from "components/Breadcrumb";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let place: Place | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			place: Place;
+		}>({
+			query: PLACE_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		place = data.place;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			place,
+		},
+	};
+}
+
+interface Props {
+	place: Place;
+}
+
+const PlaceAbout = ({ place }: Props) => {
+	if (!place) {
+		return <Layout>Error fetching Place</Layout>;
+	}
+
+	const { name, slug, description, aliases } = place;
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - About`}>
+			<Breadcrumb
+				items={[
+					{ label: "Places", href: "/entities/places" },
+					{ label: name, href: `/entities/places/${slug}` },
+					{ label: "About" },
+				]}
+				className="mb-6"
+			/>
+
+			{description && (
+				<div className="mb-4">
+					Description:
+					<br />
+					<span className="text-gray-500">{description}</span>
+				</div>
+			)}
+			{aliases && (
+				<div className="mb-4">
+					Aliases:
+					<br />
+					<span className="text-gray-500">{aliases}</span>
+				</div>
+			)}
+			<Link href={`/entities/places/${slug}/edit`}>Edit</Link>
+		</Layout>
+	);
+};
+
+export default PlaceAbout;

--- a/web/pages/entities/places/[slug]/tags.tsx
+++ b/web/pages/entities/places/[slug]/tags.tsx
@@ -1,0 +1,102 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+
+import { Place } from "types";
+import TagService from "services/Tag";
+import { API_URL } from "apolloClient";
+import { PLACE_QUERY } from "pages/entities/places/[slug]";
+
+import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
+import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import AddTagButton from "components/AddTagButton";
+import EditTagsButton from "components/EditTagsButton";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let place: Place | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			place: Place;
+		}>({
+			query: PLACE_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		place = data.place;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			place,
+		},
+	};
+}
+
+interface Props {
+	place: Place;
+}
+
+const PlaceTags = ({ place }: Props) => {
+	if (!place) {
+		return <Layout>Error fetching Place</Layout>;
+	}
+
+	const { name, slug, tags } = place;
+	const sortedTags = TagService.sort(tags);
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - Tags`}>
+			<Breadcrumb
+				items={[
+					{ label: "Places", href: "/entities/places" },
+					{ label: name, href: `/entities/places/${slug}` },
+					{ label: "Tags" },
+				]}
+				className="mb-6"
+			/>
+
+			{sortedTags.map((tag, index) => (
+				<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
+			))}
+			<div>
+				<AddTagButton
+					entity={place}
+					onSuccess={() => window.location.reload()}
+				/>
+				{sortedTags.length > 0 && (
+					<>
+						<span className="text-gray-500 px-2">/</span>
+						<EditTagsButton
+							entity={place}
+							onSuccess={() => window.location.reload()}
+						/>
+					</>
+				)}
+			</div>
+		</Layout>
+	);
+};
+
+export default PlaceTags;

--- a/web/pages/entities/tunes/[slug].tsx
+++ b/web/pages/entities/tunes/[slug].tsx
@@ -1,22 +1,14 @@
-import { useMemo } from "react";
 import { useRouter } from "next/router";
-import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Tune, ViewAs } from "types";
-import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
-import useFilters from "hooks/useFilters";
-import TagService from "services/Tag";
+import { Tune } from "types";
 
 import Layout from "components/Layout";
 import LoadingBlock from "components/LoadingBlock";
-import AudioItem from "components/AudioItem";
-import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
-import AddTagButton from "components/AddTagButton";
-import EditTagsButton from "components/EditTagsButton";
+import ViewEntity from "components/ViewEntity";
 
-const TUNE_QUERY = gql`
+export const TUNE_QUERY = gql`
 	query Tune($slug: String!) {
 		tune(slug: $slug) {
 			...Tune
@@ -29,106 +21,13 @@ const ViewTuneBySlug = () => {
 	const router = useRouter();
 	const { slug } = router.query;
 
-	const { data: tuneData, error: tuneError } = useQuery<{ tune: Tune }>(
-		TUNE_QUERY,
-		{
-			variables: { slug },
-			skip: !slug,
-			fetchPolicy: "cache-and-network",
-		}
-	);
-	const { tune } = tuneData ?? {};
-	const { name, aliases, tags, theSessionTuneId, type, mode, meter, abc } =
-		tune ?? {};
-	const sortedTags = TagService.sort(tags);
-
-	const [
-		audioItems = [],
-		{ loading: audioItemsLoading, error: audioItemsError },
-		fetchNextPageOfAudioItems,
-	] = useAudioItemsTaggedWithEntity({ entity: tuneData?.tune });
-
-	const { Filters, filtersProps, viewAs } = useFilters({
-		defaultViewAs: ViewAs.Card,
+	const { data: tuneData, error: tuneError } = useQuery<{
+		tune: Tune;
+	}>(TUNE_QUERY, {
+		variables: { slug },
+		skip: !slug,
 	});
-
-	const aboutMarkup = useMemo(
-		() => (
-			<>
-				{theSessionTuneId && (
-					<div className="mb-4">
-						<div className="italic text-gray-500">
-							We source all of our Tune data from a wonderful community project
-							called The Session.
-						</div>
-						<a
-							href={`https://thesession.org/tunes/${theSessionTuneId}`}
-							target="_blank"
-						>
-							View or Edit This Tune on The Session{" "}
-							<i className="material-icons text-sm">launch</i>
-						</a>
-					</div>
-				)}
-				{aliases && (
-					<div className="mb-4">
-						Aliases:
-						<br />
-						<span className="text-gray-500">{aliases}</span>
-					</div>
-				)}
-				{type && (
-					<div className="mb-4">
-						Type:
-						<br />
-						<span className="text-gray-500">{type}</span>
-					</div>
-				)}
-				{meter && (
-					<div className="mb-4">
-						Meter:
-						<br />
-						<span className="text-gray-500">{meter}</span>
-					</div>
-				)}
-				{mode && (
-					<div className="mb-4">
-						Mode:
-						<br />
-						<span className="text-gray-500">{mode}</span>
-					</div>
-				)}
-				{abc && (
-					<div className="mb-4">
-						ABC:
-						<br />
-						<span className="text-gray-500">{abc}</span>
-					</div>
-				)}
-			</>
-		),
-		[aliases, slug, theSessionTuneId, type, meter, mode, abc]
-	);
-
-	const tagsMarkup = useMemo(
-		() => (
-			<>
-				{sortedTags.map((tag, index) => (
-					<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
-				))}
-				<div>
-					<AddTagButton entity={tune} />
-					{sortedTags.length > 0 && (
-						<>
-							<span className="text-gray-500 px-2">/</span>
-							<EditTagsButton entity={tune} />
-						</>
-					)}
-				</div>
-			</>
-		),
-		[sortedTags, tune]
-	);
+	const { tune } = tuneData ?? {};
 
 	let statusMessage;
 	if (!tuneData && !tuneError) {
@@ -141,66 +40,9 @@ const ViewTuneBySlug = () => {
 		return <Layout>{statusMessage}</Layout>;
 	}
 
-	const shouldShowAudioItems = audioItems.length > 0;
-	const noAudioItemsFound =
-		!audioItemsLoading && !audioItemsError && audioItems.length === 0;
-
 	return (
-		<Layout pageTitle={`Trad Archive - ${name}`}>
-			<div className="flex flex-col md:flex-row">
-				<div className="flex flex-1 flex-col mb-8">
-					<div className="flex flex-row items-center mb-1">
-						<Link href="/entities/tunes">
-							<a className="mr-1">Tunes</a>
-						</Link>
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{name}</h1>
-
-					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
-
-					{shouldShowAudioItems && (
-						<>
-							<Filters {...filtersProps} className="mb-6" />
-
-							{audioItems.map((audioItem, index) => (
-								<AudioItem
-									viewAs={viewAs}
-									audioItem={audioItem}
-									key={index}
-									className={viewAs === ViewAs.List ? "mb-4" : "mb-6"}
-								/>
-							))}
-							{!audioItemsLoading && (
-								<button
-									className="btn-text"
-									onClick={fetchNextPageOfAudioItems}
-								>
-									Load More
-								</button>
-							)}
-						</>
-					)}
-					{audioItemsLoading && <LoadingBlock />}
-					{noAudioItemsFound && (
-						<div className="text-gray-500">
-							No Audio Items tagged with this yet
-						</div>
-					)}
-					{audioItemsError && (
-						<div className="text-red-600">Error fetching Audio Items</div>
-					)}
-				</div>
-
-				<div className="hidden md:flex flex-col items-start md:ml-8 md:pl-8 md:w-1/4 md:border-l md:border-gray-300">
-					<h3 className="mb-4">About</h3>
-					{aboutMarkup}
-					<h3 className="mt-8 mb-4">Tags</h3>
-					{tagsMarkup}
-				</div>
-			</div>
+		<Layout pageTitle={`Trad Archive - ${tune.name}`}>
+			<ViewEntity entity={tune} />
 		</Layout>
 	);
 };

--- a/web/pages/entities/tunes/[slug].tsx
+++ b/web/pages/entities/tunes/[slug].tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { EntityFragments } from "fragments";
-import { Tune, FilterType, ViewAs } from "types";
+import { Tune, ViewAs } from "types";
 import useAudioItemsTaggedWithEntity from "hooks/useAudioItemsTaggedWithEntity";
 import useFilters from "hooks/useFilters";
 import TagService from "services/Tag";
@@ -49,7 +49,7 @@ const ViewTuneBySlug = () => {
 	] = useAudioItemsTaggedWithEntity({ entity: tuneData?.tune });
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const aboutMarkup = useMemo(

--- a/web/pages/entities/tunes/[slug]/about.tsx
+++ b/web/pages/entities/tunes/[slug]/about.tsx
@@ -1,0 +1,134 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+import Link from "next/link";
+
+import { Tune } from "types";
+import { API_URL } from "apolloClient";
+
+import Layout from "components/Layout";
+import { TUNE_QUERY } from "pages/entities/tunes/[slug]";
+import Breadcrumb from "components/Breadcrumb";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let tune: Tune | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			tune: Tune;
+		}>({
+			query: TUNE_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		tune = data.tune;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			tune,
+		},
+	};
+}
+
+interface Props {
+	tune: Tune;
+}
+
+const TuneAbout = ({ tune }: Props) => {
+	if (!tune) {
+		return <Layout>Error fetching Tune</Layout>;
+	}
+
+	const { name, slug, aliases, theSessionTuneId, type, mode, meter, abc } =
+		tune;
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - About`}>
+			<Breadcrumb
+				items={[
+					{ label: "Tunes", href: "/entities/tunes" },
+					{ label: name, href: `/entities/tunes/${slug}` },
+					{ label: "About" },
+				]}
+				className="mb-6"
+			/>
+
+			<>
+				{theSessionTuneId && (
+					<div className="mb-4">
+						<div className="italic text-gray-500">
+							We source all of our Tune data from a wonderful community project
+							called The Session.
+						</div>
+						<a
+							href={`https://thesession.org/tunes/${theSessionTuneId}`}
+							target="_blank"
+						>
+							View or Edit This Tune on The Session{" "}
+							<i className="material-icons text-sm">launch</i>
+						</a>
+					</div>
+				)}
+				{aliases && (
+					<div className="mb-4">
+						Aliases:
+						<br />
+						<span className="text-gray-500">{aliases}</span>
+					</div>
+				)}
+				{type && (
+					<div className="mb-4">
+						Type:
+						<br />
+						<span className="text-gray-500">{type}</span>
+					</div>
+				)}
+				{meter && (
+					<div className="mb-4">
+						Meter:
+						<br />
+						<span className="text-gray-500">{meter}</span>
+					</div>
+				)}
+				{mode && (
+					<div className="mb-4">
+						Mode:
+						<br />
+						<span className="text-gray-500">{mode}</span>
+					</div>
+				)}
+				{abc && (
+					<div className="mb-4">
+						ABC:
+						<br />
+						<span className="text-gray-500">{abc}</span>
+					</div>
+				)}
+			</>
+			<Link href={`/entities/tunes/${slug}/edit`}>Edit</Link>
+		</Layout>
+	);
+};
+
+export default TuneAbout;

--- a/web/pages/entities/tunes/[slug]/tags.tsx
+++ b/web/pages/entities/tunes/[slug]/tags.tsx
@@ -1,0 +1,102 @@
+import {
+	ApolloClient,
+	InMemoryCache,
+	NormalizedCacheObject,
+} from "@apollo/client";
+
+import { Tune } from "types";
+import TagService from "services/Tag";
+import { API_URL } from "apolloClient";
+import { TUNE_QUERY } from "pages/entities/tunes/[slug]";
+
+import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
+import TagWithRelationshipToObject from "components/TagWithRelationshipToObject";
+import AddTagButton from "components/AddTagButton";
+import EditTagsButton from "components/EditTagsButton";
+
+// Attempt to reuse instance of server side Apollo Client between runs of
+// getStaticProps, to avoid creating a new DB connection on every request
+let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
+
+export async function getServerSideProps(context) {
+	let tune: Tune | undefined;
+
+	try {
+		if (!serverSideApolloClient) {
+			serverSideApolloClient = new ApolloClient({
+				uri: API_URL,
+				credentials: "include",
+				cache: new InMemoryCache(),
+				defaultOptions: {
+					query: {
+						// Force server-side queries to get the latest data each time
+						fetchPolicy: "no-cache",
+					},
+				},
+			});
+		}
+
+		const { data } = await serverSideApolloClient.query<{
+			tune: Tune;
+		}>({
+			query: TUNE_QUERY,
+			variables: { slug: context.params.slug },
+		});
+		tune = data.tune;
+	} catch {
+		//
+	}
+	return {
+		props: {
+			tune,
+		},
+	};
+}
+
+interface Props {
+	tune: Tune;
+}
+
+const TuneTags = ({ tune }: Props) => {
+	if (!tune) {
+		return <Layout>Error fetching Tune</Layout>;
+	}
+
+	const { name, slug, tags } = tune;
+	const sortedTags = TagService.sort(tags);
+
+	return (
+		<Layout pageTitle={`Trad Archive - ${name} - Tags`}>
+			<Breadcrumb
+				items={[
+					{ label: "Tunes", href: "/entities/tunes" },
+					{ label: name, href: `/entities/tunes/${slug}` },
+					{ label: "Tags" },
+				]}
+				className="mb-6"
+			/>
+
+			{sortedTags.map((tag, index) => (
+				<TagWithRelationshipToObject tag={tag} key={index} className="mb-4" />
+			))}
+			<div>
+				<AddTagButton
+					entity={tune}
+					onSuccess={() => window.location.reload()}
+				/>
+				{sortedTags.length > 0 && (
+					<>
+						<span className="text-gray-500 px-2">/</span>
+						<EditTagsButton
+							entity={tune}
+							onSuccess={() => window.location.reload()}
+						/>
+					</>
+				)}
+			</div>
+		</Layout>
+	);
+};
+
+export default TuneTags;

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -12,7 +12,6 @@ import {
 	Comment,
 	Collection,
 	EntityStatus,
-	FilterType,
 	SortBy,
 	ViewAs,
 } from "types";
@@ -32,7 +31,6 @@ import LoadingBlock from "components/LoadingBlock";
 const NUM_AUDIO_ITEMS_TO_FETCH = 10;
 const NUM_COMMENTS_TO_FETCH = 5;
 const NUM_COLLECTIONS_TO_FETCH = 5;
-const DEFAULT_SORT_BY = SortBy.RecentlyTagged;
 
 interface QueryVariables {
 	input: {
@@ -274,8 +272,8 @@ export default function Home({
 	]);
 
 	const { Filters, filtersProps, sortBy, viewAs } = useFilters({
-		types: [FilterType.SortBy, FilterType.ViewAs],
-		defaultSortBy: DEFAULT_SORT_BY,
+		defaultSortBy: SortBy.RecentlyTagged,
+		defaultViewAs: ViewAs.Card,
 	});
 
 	// These queries skip the initial network request if the cache was

--- a/web/pages/saved-items.tsx
+++ b/web/pages/saved-items.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 
 import useSavedItemsForUser from "hooks/useSavedItemsForUser";
 import useFilters from "hooks/useFilters";
-import { FilterType, ViewAs } from "types";
+import { ViewAs } from "types";
 
 import Layout from "components/Layout";
 import RequireUser from "components/RequireUser";
@@ -13,7 +13,6 @@ const SavedItems = () => {
 	const [savedItems, { loading, error }] = useSavedItemsForUser();
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
 		defaultViewAs: ViewAs.List,
 	});
 

--- a/web/pages/users/[id].tsx
+++ b/web/pages/users/[id].tsx
@@ -4,13 +4,14 @@ import Link from "next/link";
 import { useQuery, gql } from "@apollo/client";
 
 import { UserFragments } from "fragments";
-import { User, FilterType } from "types";
+import { User, ViewAs } from "types";
 import DateTimeService from "services/DateTime";
 import EntityService from "services/Entity";
 import useAudioItemsCreatedByUser from "hooks/useAudioItemsCreatedByUser";
 import useFilters from "hooks/useFilters";
 
 import Layout from "components/Layout";
+import Breadcrumb from "components/Breadcrumb";
 import LoadingBlock from "components/LoadingBlock";
 import AudioItem from "components/AudioItem";
 
@@ -42,7 +43,7 @@ const ViewUserById = () => {
 	] = useAudioItemsCreatedByUser(userData?.user);
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		types: [FilterType.ViewAs],
+		defaultViewAs: ViewAs.Card,
 	});
 
 	const aboutMarkup = useMemo(
@@ -90,13 +91,10 @@ const ViewUserById = () => {
 		<Layout pageTitle={`Trad Archive - ${username}`}>
 			<div className="flex flex-col-reverse md:flex-row">
 				<div className="flex flex-1 flex-col pb-8">
-					<div className="flex flex-row items-center">
-						Users{" "}
-						<i className="material-icons text-gray-500 text-base">
-							keyboard_arrow_right
-						</i>
-					</div>
-					<h1 className="mb-6">{username}</h1>
+					<Breadcrumb
+						className="mb-6"
+						items={[{ label: "Users" }, { label: username }]}
+					/>
 
 					<div className="flex-col mb-8 md:hidden">{aboutMarkup}</div>
 

--- a/web/services/Entity.ts
+++ b/web/services/Entity.ts
@@ -5,32 +5,67 @@ const cleanSlug = (rawSlug: string) => {
 	return slugWithHyphens.replace(/[^a-zA-Z0-9-]/g, "").toLowerCase();
 };
 
-const makeHrefForView = (entity: Entity) => {
+const makeHrefForTopLevel = (entity: Entity) => {
 	switch (entity?.entityType) {
 		case EntityType.AudioItem:
-			return `/entities/audio-items/${entity.slug}`;
+			return "/entities/audio-items";
 		case EntityType.Person:
-			return `/entities/people/${entity.slug}`;
+			return "/entities/people";
 		case EntityType.Instrument:
-			return `/entities/instruments/${entity.slug}`;
+			return "/entities/instruments";
 		case EntityType.Place:
-			return `/entities/places/${entity.slug}`;
+			return "/entities/places";
 		case EntityType.Tune:
-			return `/entities/tunes/${entity.slug}`;
+			return "/entities/tunes";
 		case EntityType.Collection:
-			return `/entities/collections/${entity.slug}`;
+			return "/entities/collections";
 		default:
 			return "";
 	}
+};
+
+const makeHrefForView = (entity: Entity) => {
+	return `${makeHrefForTopLevel(entity)}/${entity.slug}`;
 };
 
 const makeHrefForEdit = (entity: Entity) => {
 	return `${makeHrefForView(entity)}/edit`;
 };
 
+const makeHrefForAbout = (entity: Entity) => {
+	return `${makeHrefForView(entity)}/about`;
+};
+
+const makeHrefForTags = (entity: Entity) => {
+	return `${makeHrefForView(entity)}/tags`;
+};
+
+const makeReadableNamePlural = (entity: Entity) => {
+	switch (entity?.entityType) {
+		case EntityType.AudioItem:
+			return "Audio Items";
+		case EntityType.Person:
+			return "People";
+		case EntityType.Instrument:
+			return "Instruments";
+		case EntityType.Place:
+			return "Places";
+		case EntityType.Tune:
+			return "Tunes";
+		case EntityType.Collection:
+			return "Collections";
+		default:
+			return "";
+	}
+};
+
 const EntityService = {
 	cleanSlug,
+	makeHrefForTopLevel,
 	makeHrefForView,
 	makeHrefForEdit,
+	makeHrefForAbout,
+	makeHrefForTags,
+	makeReadableNamePlural,
 };
 export default EntityService;

--- a/web/styles/globals.css
+++ b/web/styles/globals.css
@@ -80,6 +80,6 @@
 	}
 
 	select {
-		@apply bg-white cursor-pointer border border-gray-300 rounded focus:outline-none focus:border-transparent focus:ring-2 focus:ring-teal-600;
+		@apply bg-white cursor-pointer border border-gray-300 rounded py-1 pl-2 pr-9 focus:outline-none focus:border-transparent focus:ring-2 focus:ring-teal-600;
 	}
 }

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,9 +1,10 @@
 const colors = require("tailwindcss/colors");
 
 module.exports = {
-	mode: "jit",
-	purge: ["./components/**/*.{js,ts,jsx,tsx}", "./pages/**/*.{js,ts,jsx,tsx}"],
-	darkMode: "media",
+	content: [
+		"./components/**/*.{js,ts,jsx,tsx}",
+		"./pages/**/*.{js,ts,jsx,tsx}",
+	],
 	theme: {
 		colors: {
 			transparent: "transparent",
@@ -30,15 +31,6 @@ module.exports = {
 			lg: "1024px",
 			xl: "1280px",
 			"2xl": "1536px",
-		},
-	},
-	variants: {
-		extend: {
-			backgroundColor: ["disabled", "checked"],
-			borderColor: ["checked", "hover"],
-			borderRadius: ["hover"],
-			cursor: ["disabled"],
-			margin: ["last"],
 		},
 	},
 	plugins: [require("@tailwindcss/forms")],

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -1,8 +1,3 @@
-export enum FilterType {
-	SortBy = "SortBy",
-	ViewAs = "ViewAs",
-}
-
 export enum SortBy {
 	RecentlyTagged = "RecentlyTagged",
 	RecentlyAdded = "RecentlyAdded",

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -1,3 +1,10 @@
+export enum PerPage {
+	Ten = 10,
+	Twenty = 20,
+	Fifty = 50,
+	Hundred = 100,
+}
+
 export enum SortBy {
 	RecentlyTagged = "RecentlyTagged",
 	RecentlyAdded = "RecentlyAdded",

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -562,9 +562,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001249"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz"
-  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
+  version "1.0.30001311"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz"
+  integrity sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==
 
 chalk@2.4.2, chalk@^2.0.0:
   version "2.4.2"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -2114,6 +2114,11 @@ react-hotkeys-hook@^3.3.1:
   dependencies:
     hotkeys-js "3.8.3"
 
+react-intersection-observer@^8.33.1:
+  version "8.33.1"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.33.1.tgz#8e6442cac7052ed63056e191b7539e423e7d5c64"
+  integrity sha512-3v+qaJvp3D1MlGHyM+KISVg/CMhPiOlO6FgPHcluqHkx4YFCLuyXNlQ/LE6UkbODXlQcLOppfX6UMxCEkUhDLw==
+
 react-is@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -218,10 +218,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@tailwindcss/forms@^0.2.1":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.2.1.tgz#3244b185854fae1a7cbe8d2456314d8b2d98cf43"
-  integrity sha512-czfvEdY+J2Ogfd6RUSr/ZSUmDxTujr34M++YLnp2cCPC3oJ4kFvFMaRXA6cEXKw7F1hJuapdjXRjsXIEXGgORg==
+"@tailwindcss/forms@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/forms/-/forms-0.4.0.tgz#a46715e347a32d216a3973eb67473bd29ae3798e"
+  integrity sha512-DeaQBx6EgEeuZPQACvC+mKneJsD8am1uiJugjgQK1+/Vt+Ai0GpFBC2T2fqnUad71WgOxyrZPE6BG1VaI6YqfQ==
   dependencies:
     mini-svg-data-uri "^1.2.3"
 
@@ -370,27 +370,22 @@ assert@2.0.0:
     object-is "^1.0.1"
     util "^0.12.0"
 
-autoprefixer@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.1.0.tgz#b19fd8524edef8c85c9db3bdb0c998de84e172fb"
-  integrity sha512-0/lBNwN+ZUnb5su18NZo5MBIjDaq6boQKZcxwy86Gip/CmXA2zZqUoFQLCNAGI5P25ZWSP2RWdhDJ8osfKEjoQ==
+autoprefixer@^10.4.2:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-10.4.2.tgz#25e1df09a31a9fba5c40b578936b90d35c9d4d3b"
+  integrity sha512-9fOPpHKuDW1w/0EKfRmVnxTDt8166MAnLI3mgZ1JCnhNtYWxcJ6Ud5CO/AVOZi/AvFa8DY9RTy3h3+tFBlrrdQ==
   dependencies:
-    browserslist "^4.15.0"
-    caniuse-lite "^1.0.30001165"
-    colorette "^1.2.1"
-    fraction.js "^4.0.12"
+    browserslist "^4.19.1"
+    caniuse-lite "^1.0.30001297"
+    fraction.js "^4.1.2"
     normalize-range "^0.1.2"
-    postcss-value-parser "^4.1.0"
+    picocolors "^1.0.0"
+    postcss-value-parser "^4.2.0"
 
 available-typed-arrays@^1.0.2:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.4.tgz#9e0ae84ecff20caae6a94a1c3bc39b955649b7a9"
   integrity sha512-SA5mXJWrId1TaQjfxUYghbqQ/hYioKmLJvPJyDuYRtXXenFNMjj4hSSt1Cf1xsuXSXrtxrVC5Ot4eU6cOtBDdA==
-
-balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
 base64-js@^1.0.2:
   version "1.5.1"
@@ -416,14 +411,6 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
-
-brace-expansion@^1.1.7:
-  version "1.1.11"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
-  integrity sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
-  dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
 
 braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
@@ -509,16 +496,16 @@ browserslist@4.16.6:
     escalade "^3.1.1"
     node-releases "^1.1.71"
 
-browserslist@^4.15.0:
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.0.tgz#410277627500be3cb28a1bfe037586fbedf9488b"
-  integrity sha512-/j6k8R0p3nxOC6kx5JGAxsnhc9ixaWJfYc+TNTzxg6+ARaESAvQGV7h0uNOB4t+pLQJZWzcrMxXOxjgsCj3dqQ==
+browserslist@^4.19.1:
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.19.1.tgz#4ac0435b35ab655896c31d53018b6dd5e9e4c9a3"
+  integrity sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==
   dependencies:
-    caniuse-lite "^1.0.30001165"
-    colorette "^1.2.1"
-    electron-to-chromium "^1.3.621"
+    caniuse-lite "^1.0.30001286"
+    electron-to-chromium "^1.4.17"
     escalade "^3.1.1"
-    node-releases "^1.1.67"
+    node-releases "^2.0.1"
+    picocolors "^1.0.0"
 
 buffer-xor@^1.0.3:
   version "1.0.3"
@@ -538,7 +525,7 @@ builtin-status-codes@^3.0.0:
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
   integrity sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=
 
-bytes@3.1.0, bytes@^3.0.0:
+bytes@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-3.1.0.tgz#f6cf7933a360e0588fa9fde85651cdc7f805d1f6"
   integrity sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==
@@ -561,7 +548,7 @@ camelcase-css@^2.0.1:
   resolved "https://registry.yarnpkg.com/camelcase-css/-/camelcase-css-2.0.1.tgz#ee978f6947914cc30c6b44741b6ed1df7f043fd5"
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
-caniuse-lite@^1.0.30001165, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
+caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228, caniuse-lite@^1.0.30001286, caniuse-lite@^1.0.30001297:
   version "1.0.30001311"
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001311.tgz"
   integrity sha512-mleTFtFKfykEeW34EyfhGIFjGCqzhh38Y0LhdQ9aWF+HorZTtdgKV/1hEE0NlFkG2ubvisPV6l400tlbPys98A==
@@ -606,10 +593,10 @@ chokidar@3.5.1:
   optionalDependencies:
     fsevents "~2.3.1"
 
-chokidar@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+chokidar@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
   dependencies:
     anymatch "~3.1.2"
     braces "~3.0.2"
@@ -663,46 +650,20 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-string@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.6.0.tgz#c3915f61fe267672cb7e1e064c9d692219f6c312"
-  integrity sha512-c/hGS+kRWJutUBEngKKmk4iH3sD59MBkoxVapS/0wgpCz2u7XsNloxknyvBhzwEs1IbV36D9PwqLPJ2DTu3vMA==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
-
-color@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/color/-/color-4.0.1.tgz#21df44cd10245a91b1ccf5ba031609b0e10e7d67"
-  integrity sha512-rpZjOKN5O7naJxkH2Rx1sZzzBgaiWECc6BYXjeCE6kF0kcASJYbUq02u7JqIHwCb/j3NhV+QhRL2683aICeGZA==
-  dependencies:
-    color-convert "^2.0.1"
-    color-string "^1.6.0"
-
-colorette@^1.2.1, colorette@^1.2.2:
+colorette@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
   integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
-
-commander@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
 
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
   integrity sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 constants-browserify@1.0.0:
   version "1.0.0"
@@ -774,16 +735,6 @@ crypto-browserify@3.12.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
     randomfill "^1.0.3"
-
-css-color-names@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
-  integrity sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=
-
-css-unit-converter@^1.1.1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/css-unit-converter/-/css-unit-converter-1.1.2.tgz#4c77f5a1954e6dbff60695ecb214e3270436ab21"
-  integrity sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==
 
 css.escape@1.5.1:
   version "1.5.1"
@@ -889,15 +840,15 @@ domain-browser@4.19.0:
   resolved "https://registry.yarnpkg.com/domain-browser/-/domain-browser-4.19.0.tgz#1093e17c0a17dbd521182fe90d49ac1370054af1"
   integrity sha512-fRA+BaAWOR/yr/t7T9E9GJztHPeFjj8U35ajyAjCDtAAnTn1Rc1f6W6VGPJrO1tkQv9zWu+JRof7z6oQtiYVFQ==
 
-electron-to-chromium@^1.3.621:
-  version "1.3.633"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.633.tgz#16dd5aec9de03894e8d14a1db4cda8a369b9b7fe"
-  integrity sha512-bsVCsONiVX1abkWdH7KtpuDAhsQ3N3bjPYhROSAXE78roJKet0Y5wznA14JE9pzbwSZmSMAW6KiKYf1RvbTJkA==
-
 electron-to-chromium@^1.3.723:
   version "1.3.796"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.796.tgz#bd74a4367902c9d432d129f265bf4542cddd9f54"
   integrity sha512-agwJFgM0FUC1UPPbQ4aII3HamaaJ09fqWGAWYHmzxDWqdmTleCHyyA0kt3fJlTd5M440IaeuBfzXzXzCotnZcQ==
+
+electron-to-chromium@^1.4.17:
+  version "1.4.68"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.68.tgz#d79447b6bd1bec9183f166bb33d4bef0d5e4e568"
+  integrity sha512-cId+QwWrV8R1UawO6b9BR1hnkJ4EJPCPAr4h315vliHUtVUJDk39Sg1PMNnaWKfj5x+93ssjeJ9LKL6r8LaMiA==
 
 elliptic@^6.5.3:
   version "6.5.4"
@@ -996,10 +947,10 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-fast-glob@^3.2.7:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
+fast-glob@^3.2.11:
+  version "3.2.11"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.11.tgz#a1172ad95ceb8a16e20caa5c5e56480e5129c1d9"
+  integrity sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==
   dependencies:
     "@nodelib/fs.stat" "^2.0.2"
     "@nodelib/fs.walk" "^1.2.3"
@@ -1043,24 +994,10 @@ foreach@^2.0.5:
   resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
   integrity sha1-C+4AUBiusmDQo6865ljdATbsG5k=
 
-fraction.js@^4.0.12:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.0.13.tgz#3c1c315fa16b35c85fffa95725a36fa729c69dfe"
-  integrity sha512-E1fz2Xs9ltlUp+qbiyx9wmt2n9dRzPsS11Jtdb8D2o+cC7wr9xkkKsVKJuBX0ST+LVS+LhLO+SbLJNtfWcJvXA==
-
-fs-extra@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-10.0.0.tgz#9ff61b655dde53fb34a82df84bb214ce802e17c1"
-  integrity sha512-C5owb14u9eJwizKGdchcDUQeFtlSHHthBk8pbX9Vc1PFZrLombudjDnNns88aYslCyF6IY5SUw3Roz6xShcEIQ==
-  dependencies:
-    graceful-fs "^4.2.0"
-    jsonfile "^6.0.1"
-    universalify "^2.0.0"
-
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
-  integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+fraction.js@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/fraction.js/-/fraction.js-4.1.3.tgz#be65b0f20762ef27e1e793860bc2dfb716e99e65"
+  integrity sha512-pUHWWt6vHzZZiQJcM6S/0PXfS+g6FM4BF5rj9wZyreivhQPdsh5PpE25VtSNxq80wHS5RfY51Ii+8Z0Zl/pmzg==
 
 fsevents@~2.3.1, fsevents@~2.3.2:
   version "2.3.2"
@@ -1095,7 +1032,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.0, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1:
+glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -1107,30 +1044,6 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@^7.0.0:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
-glob@^7.1.3:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.0.4"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
-
 google-libphonenumber@^3.2.8:
   version "3.2.15"
   resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.15.tgz#3a01dc554dbf83c754f249c16df3605e5d154bb9"
@@ -1140,11 +1053,6 @@ graceful-fs@^4.1.2:
   version "4.2.6"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
-
-graceful-fs@^4.1.6, graceful-fs@^4.2.0:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
-  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 graphql-tag@^2.12.3:
   version "2.12.5"
@@ -1207,11 +1115,6 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-hex-color-regex@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
-  integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
-
 hmac-drbg@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -1232,21 +1135,6 @@ hotkeys-js@3.8.3:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/hotkeys-js/-/hotkeys-js-3.8.3.tgz#0331c2cde770e62d51d5d023133f7c4395f59008"
   integrity sha512-rUmoryG4lEAtkjF5tcYaihrVoE86Fdw1BLqO/UiBWOOF56h32a6ax8oV4urBlinVtNNtArLlBq8igGfZf2tQnw==
-
-hsl-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hsl-regex/-/hsl-regex-1.0.0.tgz#d49330c789ed819e276a4c0d272dffa30b18fe6e"
-  integrity sha1-1JMwx4ntgZ4nakwNJy3/owsY/m4=
-
-hsla-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
-  integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
-
-html-tags@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
-  integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
 http-errors@1.7.3:
   version "1.7.3"
@@ -1312,20 +1200,7 @@ import-from@^3.0.0:
   dependencies:
     resolve-from "^5.0.0"
 
-indexes-of@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/indexes-of/-/indexes-of-1.0.1.tgz#f30f716c8e2bd346c7b67d3df3915566a7c05607"
-  integrity sha1-8w9xbI4r00bHtn0985FVZqfAVgc=
-
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
-  integrity sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1351,11 +1226,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
-is-arrayish@^0.3.1:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
-  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
-
 is-bigint@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
@@ -1380,22 +1250,10 @@ is-callable@^1.1.4, is-callable@^1.2.3:
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
   integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
-is-color-stop@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-color-stop/-/is-color-stop-1.1.0.tgz#cfff471aee4dd5c9e158598fbe12967b5cdad345"
-  integrity sha1-z/9HGu5N1cnhWFmPvhKWe1za00U=
-  dependencies:
-    css-color-names "^0.0.4"
-    hex-color-regex "^1.1.0"
-    hsl-regex "^1.0.0"
-    hsla-regex "^1.0.0"
-    rgb-regex "^1.0.1"
-    rgba-regex "^1.0.0"
-
-is-core-module@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
-  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+is-core-module@^2.8.1:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.8.1.tgz#f59fdfca701d5879d0a6b100a40aa1560ce27211"
+  integrity sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==
   dependencies:
     has "^1.0.3"
 
@@ -1508,15 +1366,6 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsonfile@^6.0.1:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
-  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  dependencies:
-    universalify "^2.0.0"
-  optionalDependencies:
-    graceful-fs "^4.1.6"
-
 lilconfig@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.0.3.tgz#68f3005e921dafbd2a2afb48379986aa6d2579fd"
@@ -1548,20 +1397,10 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash.topath@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/lodash.topath/-/lodash.topath-4.5.2.tgz#3616351f3bba61994a0931989660bd03254fd009"
-  integrity sha1-NhY1Hzu6YZlKCTGYlmC9AyVP0Ak=
-
 lodash@^4.17.20:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
-
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
@@ -1627,37 +1466,25 @@ minimalistic-crypto-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz#f6c00c1c0b082246e5c4d99dfb8c7c083b2b582a"
   integrity sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=
 
-minimatch@^3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
-
-modern-normalize@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/modern-normalize/-/modern-normalize-1.1.0.tgz#da8e80140d9221426bd4f725c6e11283d34f90b7"
-  integrity sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==
 
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-nanoid@^3.1.20:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
-
 nanoid@^3.1.23:
   version "3.1.23"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.23.tgz#f744086ce7c2bc47ee0a8472574d5c78e4183a81"
   integrity sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==
+
+nanoid@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 next@^12.0.4:
   version "12.0.4"
@@ -1726,13 +1553,6 @@ next@^12.0.4:
     "@next/swc-win32-ia32-msvc" "12.0.4"
     "@next/swc-win32-x64-msvc" "12.0.4"
 
-node-emoji@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/node-emoji/-/node-emoji-1.11.0.tgz#69a0150e6946e2f115e9d7ea4df7971e2628301c"
-  integrity sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==
-  dependencies:
-    lodash "^4.17.21"
-
 node-fetch@2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
@@ -1745,15 +1565,15 @@ node-html-parser@1.4.9:
   dependencies:
     he "1.2.0"
 
-node-releases@^1.1.67:
-  version "1.1.67"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
-  integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
-
 node-releases@^1.1.71:
   version "1.1.73"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
   integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
+
+node-releases@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.2.tgz#7139fe71e2f4f11b47d4d2986aaf8c48699e0c01"
+  integrity sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
@@ -1802,13 +1622,6 @@ object.assign@^4.1.2:
     define-properties "^1.1.3"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
-
-once@^1.3.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
-  integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
-  dependencies:
-    wrappy "1"
 
 optimism@^0.16.1:
   version "0.16.1"
@@ -1892,15 +1705,10 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz#174b9268735534ffbc7ace6bf53a5a9e1b5c5f5f"
-  integrity sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
-
-path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+path-parse@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -1917,6 +1725,11 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+picocolors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
+  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
   version "2.3.0"
@@ -1935,13 +1748,12 @@ platform@1.3.6:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-postcss-js@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-3.0.3.tgz#2f0bd370a2e8599d45439f6970403b5873abda33"
-  integrity sha512-gWnoWQXKFw65Hk/mi2+WTQTHdPD5UJdDXZmX073EY/B3BWnYjO4F4t0VneTCnCGQ5E5GsCdMkzPaTXwl3r5dJw==
+postcss-js@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-js/-/postcss-js-4.0.0.tgz#31db79889531b80dc7bc9b0ad283e418dce0ac00"
+  integrity sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==
   dependencies:
     camelcase-css "^2.0.1"
-    postcss "^8.1.6"
 
 postcss-load-config@^3.1.0:
   version "3.1.0"
@@ -1959,16 +1771,6 @@ postcss-nested@5.0.6:
   dependencies:
     postcss-selector-parser "^6.0.6"
 
-postcss-selector-parser@^6.0.2:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.4.tgz#56075a1380a04604c38b063ea7767a129af5c2b3"
-  integrity sha512-gjMeXBempyInaBqpp8gODmwZ52WaYsVOsfr4L4lDQ7n3ncD6mEyySiDtgzCT+NYC0mmeOLvtsF8iaEf0YT6dBw==
-  dependencies:
-    cssesc "^3.0.0"
-    indexes-of "^1.0.1"
-    uniq "^1.0.1"
-    util-deprecate "^1.0.2"
-
 postcss-selector-parser@^6.0.6:
   version "6.0.6"
   resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz#2c5bba8174ac2f6981ab631a42ab0ee54af332ea"
@@ -1977,17 +1779,20 @@ postcss-selector-parser@^6.0.6:
     cssesc "^3.0.0"
     util-deprecate "^1.0.2"
 
-postcss-value-parser@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
-  integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
+postcss-selector-parser@^6.0.9:
+  version "6.0.9"
+  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz#ee71c3b9ff63d9cd130838876c13a2ec1a992b2f"
+  integrity sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==
+  dependencies:
+    cssesc "^3.0.0"
+    util-deprecate "^1.0.2"
 
-postcss-value-parser@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
-  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+postcss-value-parser@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
+  integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@8.2.15, postcss@^8.2.15:
+postcss@8.2.15:
   version "8.2.15"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.15.tgz#9e66ccf07292817d226fc315cbbf9bc148fbca65"
   integrity sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==
@@ -1996,19 +1801,14 @@ postcss@8.2.15, postcss@^8.2.15:
     nanoid "^3.1.23"
     source-map "^0.6.1"
 
-postcss@^8.1.6, postcss@^8.2.1:
-  version "8.2.1"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.2.1.tgz#eabc5557c4558059b9d9e5b15bce7ffa9089c2a8"
-  integrity sha512-RhsqOOAQzTgh1UB/IZdca7F9WDb7SUCR2Vnv1x7DbvuuggQIpoDwjK+q0rzoPffhYvWNKX5JSwS4so4K3UC6vA==
+postcss@^8.4.6:
+  version "8.4.6"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.6.tgz#c5ff3c3c457a23864f32cb45ac9b741498a09ae1"
+  integrity sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==
   dependencies:
-    colorette "^1.2.1"
-    nanoid "^3.1.20"
-    source-map "^0.6.1"
-
-pretty-hrtime@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
-  integrity sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=
+    nanoid "^3.2.0"
+    picocolors "^1.0.0"
+    source-map-js "^1.0.2"
 
 process@0.11.10:
   version "0.11.10"
@@ -2040,16 +1840,6 @@ punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-purgecss@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/purgecss/-/purgecss-4.0.3.tgz#8147b429f9c09db719e05d64908ea8b672913742"
-  integrity sha512-PYOIn5ibRIP34PBU9zohUcCI09c7drPJJtTDAc0Q6QlRz2/CHQ8ywGLdE7ZhxU2VTqB7p5wkvj5Qcm05Rz3Jmw==
-  dependencies:
-    commander "^6.0.0"
-    glob "^7.0.0"
-    postcss "^8.2.1"
-    postcss-selector-parser "^6.0.2"
 
 querystring-es3@0.2.1:
   version "0.2.1"
@@ -2165,14 +1955,6 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
-reduce-css-calc@^2.1.8:
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz#7ef8761a28d614980dc0c982f772c93f7a99de03"
-  integrity sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==
-  dependencies:
-    css-unit-converter "^1.1.1"
-    postcss-value-parser "^3.3.0"
-
 regenerator-runtime@0.13.4:
   version "0.13.4"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.4.tgz#e96bf612a3362d12bb69f7e8f74ffeab25c7ac91"
@@ -2193,35 +1975,19 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
-  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
+resolve@^1.22.0:
+  version "1.22.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.0.tgz#5e0b8c67c15df57a89bdbabe603a002f21731198"
+  integrity sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==
   dependencies:
-    is-core-module "^2.2.0"
-    path-parse "^1.0.6"
+    is-core-module "^2.8.1"
+    path-parse "^1.0.7"
+    supports-preserve-symlinks-flag "^1.0.0"
 
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
-
-rgb-regex@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/rgb-regex/-/rgb-regex-1.0.1.tgz#c0e0d6882df0e23be254a475e8edd41915feaeb1"
-  integrity sha1-wODWiC3w4jviVKR16O3UGRX+rrE=
-
-rgba-regex@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
-  integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
-
-rimraf@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
-  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
-  dependencies:
-    glob "^7.1.3"
 
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
@@ -2298,12 +2064,10 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
-simple-swizzle@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
-  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
-  dependencies:
-    is-arrayish "^0.3.1"
+source-map-js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
+  integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
 source-map@0.7.3:
   version "0.7.3"
@@ -2439,48 +2203,41 @@ supports-color@^8.0.0:
   dependencies:
     has-flag "^4.0.0"
 
+supports-preserve-symlinks-flag@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
+  integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
+
 symbol-observable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
   integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
-tailwindcss@^2.2.16:
-  version "2.2.16"
-  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-2.2.16.tgz#32f81bdf1758b639cb83b9d30bf7cbecdda49e5e"
-  integrity sha512-EireCtpQyyJ4Xz8NYzHafBoy4baCOO96flM0+HgtsFcIQ9KFy/YBK3GEtlnD+rXen0e4xm8t3WiUcKBJmN6yjg==
+tailwindcss@^3.0.19:
+  version "3.0.19"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-3.0.19.tgz#cd789953e6762af2e80c5a3e5d6da3a975ee8215"
+  integrity sha512-rjsdfz/qZya5xQ0OVynEMETgWq1CacmftgMYeXXh6bRM5vxsNwRSbMJsCCIjq/w67om9VP/AFMolOwiE+5VKig==
   dependencies:
     arg "^5.0.1"
-    bytes "^3.0.0"
     chalk "^4.1.2"
-    chokidar "^3.5.2"
-    color "^4.0.1"
+    chokidar "^3.5.3"
+    color-name "^1.1.4"
     cosmiconfig "^7.0.1"
     detective "^5.2.0"
     didyoumean "^1.2.2"
     dlv "^1.1.3"
-    fast-glob "^3.2.7"
-    fs-extra "^10.0.0"
-    glob-parent "^6.0.1"
-    html-tags "^3.1.0"
-    is-color-stop "^1.1.0"
-    is-glob "^4.0.1"
-    lodash "^4.17.21"
-    lodash.topath "^4.5.2"
-    modern-normalize "^1.1.0"
-    node-emoji "^1.11.0"
+    fast-glob "^3.2.11"
+    glob-parent "^6.0.2"
+    is-glob "^4.0.3"
     normalize-path "^3.0.0"
     object-hash "^2.2.0"
-    postcss-js "^3.0.3"
+    postcss-js "^4.0.0"
     postcss-load-config "^3.1.0"
     postcss-nested "5.0.6"
-    postcss-selector-parser "^6.0.6"
-    postcss-value-parser "^4.1.0"
-    pretty-hrtime "^1.0.3"
-    purgecss "^4.0.3"
+    postcss-selector-parser "^6.0.9"
+    postcss-value-parser "^4.2.0"
     quick-lru "^5.1.1"
-    reduce-css-calc "^2.1.8"
-    resolve "^1.20.0"
-    tmp "^0.2.1"
+    resolve "^1.22.0"
 
 timers-browserify@2.0.12:
   version "2.0.12"
@@ -2488,13 +2245,6 @@ timers-browserify@2.0.12:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-tmp@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.1.tgz#8457fc3037dcf4719c251367a1af6500ee1ccf14"
-  integrity sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
-  dependencies:
-    rimraf "^3.0.0"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -2566,16 +2316,6 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
-
-uniq@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
-  integrity sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=
-
-universalify@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
-  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unpipe@1.0.0:
   version "1.0.0"
@@ -2661,11 +2401,6 @@ which-typed-array@^1.1.2:
     function-bind "^1.1.1"
     has-symbols "^1.0.1"
     is-typed-array "^1.1.3"
-
-wrappy@1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-  integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
- Before this it was easy to get lost in endless scroll while browsing an Entity like a Collection. 
- Now there is pagination
  - Implemented this in the reusable `Filters` component so it can be used elsewhere
- When you scroll down the page, the pagination stays visible as a fixed subheader
- Break out an Entity's `About` and `Tags` into their own pages
- Add GitHub Discussions as the main feedback/bugs call-to-action in the footer

<img width="1431" alt="Screen Shot 2022-02-10 at 4 46 16 PM" src="https://user-images.githubusercontent.com/1173791/153463642-b01d4b56-1b23-41ac-a946-2c67ce0d1d11.png">

<img width="1431" alt="Screen Shot 2022-02-10 at 4 46 31 PM" src="https://user-images.githubusercontent.com/1173791/153463666-3b32ace0-8c78-486d-9e55-73aa25486e2b.png">
