### PR TITLE
More fixes based on beta feedback

### DIFF
--- a/api/src/apollo.ts
+++ b/api/src/apollo.ts
@@ -17,6 +17,7 @@ import { InstrumentResolver } from "./resolvers/InstrumentResolver";
 import { PlaceResolver } from "./resolvers/PlaceResolver";
 import { TuneResolver } from "./resolvers/TuneResolver";
 import { CollectionResolver } from "./resolvers/CollectionResolver";
+import { StatsResolver } from "./resolvers/StatsResolver";
 
 export const makeSchema = () => {
 	return buildSchema({
@@ -36,6 +37,7 @@ export const makeSchema = () => {
 			PlaceResolver,
 			TuneResolver,
 			CollectionResolver,
+			StatsResolver,
 		],
 		dateScalarMode: "isoDate",
 		authChecker,

--- a/api/src/resolvers/EntityResolver.ts
+++ b/api/src/resolvers/EntityResolver.ts
@@ -100,79 +100,49 @@ export class EntityResolver {
 		const personQuery = entityManager
 			.createQueryBuilder(Person, "person")
 			.leftJoinAndSelect("person.createdByUser", "createdByUser")
-			.where("MATCH(name) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(aliases) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(description) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
+			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(description) LIKE "%${cleanedSearchTerm}%"`)
 			.take(takeFromEach)
 			.getMany();
 		const instrumentQuery = entityManager
 			.createQueryBuilder(Instrument, "instrument")
 			.leftJoinAndSelect("instrument.createdByUser", "createdByUser")
-			.where("MATCH(name) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(aliases) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(description) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
+			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(description) LIKE "%${cleanedSearchTerm}%"`)
 			.take(takeFromEach)
 			.getMany();
 		const placeQuery = entityManager
 			.createQueryBuilder(Place, "place")
 			.leftJoinAndSelect("place.createdByUser", "createdByUser")
-			.where("MATCH(name) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(aliases) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(description) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
+			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(description) LIKE "%${cleanedSearchTerm}%"`)
 			.take(takeFromEach)
 			.getMany();
 		const tuneQuery = entityManager
 			.createQueryBuilder(Tune, "tune")
 			.leftJoinAndSelect("tune.createdByUser", "createdByUser")
 			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
-			.orWhere(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
 			.orWhere("theSessionTuneId = :term", { term: cleanedSearchTerm })
 			.take(takeFromEach)
 			.getMany();
 		const collectionQuery = entityManager
 			.createQueryBuilder(Collection, "collection")
 			.leftJoinAndSelect("collection.createdByUser", "createdByUser")
-			.where("MATCH(name) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(aliases) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(description) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
+			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(description) LIKE "%${cleanedSearchTerm}%"`)
 			.take(takeFromEach)
 			.getMany();
 		const audioItemQuery = entityManager
 			.createQueryBuilder(AudioItem, "audioItem")
 			.leftJoinAndSelect("audioItem.createdByUser", "createdByUser")
-			.where("MATCH(name) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(aliases) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
-			.orWhere("MATCH(description) AGAINST (:term IN NATURAL LANGUAGE MODE)", {
-				term: cleanedSearchTerm,
-			})
+			.where(`LOWER(name) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(aliases) LIKE "%${cleanedSearchTerm}%"`)
+			.orWhere(`LOWER(description) LIKE "%${cleanedSearchTerm}%"`)
 			.take(takeFromEach)
 			.getMany();
 

--- a/api/src/resolvers/StatsResolver.ts
+++ b/api/src/resolvers/StatsResolver.ts
@@ -2,6 +2,7 @@ import { Resolver, Int, Query, ObjectType, Field } from "type-graphql";
 import { getManager } from "typeorm";
 import { AudioItem } from "../models/entities/AudioItem";
 import { Tag } from "../models/Tag";
+import { Comment } from "../models/Comment";
 import { User } from "../models/User";
 
 @ObjectType()
@@ -13,6 +14,9 @@ class Stats {
 	numTagsAllTime!: number;
 
 	@Field(() => Int)
+	numCommentsAllTime!: number;
+
+	@Field(() => Int)
 	numUsersAllTime!: number;
 }
 
@@ -20,15 +24,21 @@ class Stats {
 export class StatsResolver {
 	@Query(() => Stats)
 	async stats() {
-		const [numAudioItemsAllTime, numTagsAllTime, numUsersAllTime] =
-			await Promise.all<number>([
-				getManager().createQueryBuilder(AudioItem, "audioItem").getCount(),
-				getManager().createQueryBuilder(Tag, "tag").getCount(),
-				getManager().createQueryBuilder(User, "user").getCount(),
-			]);
+		const [
+			numAudioItemsAllTime,
+			numTagsAllTime,
+			numCommentsAllTime,
+			numUsersAllTime,
+		] = await Promise.all<number>([
+			getManager().createQueryBuilder(AudioItem, "audioItem").getCount(),
+			getManager().createQueryBuilder(Tag, "tag").getCount(),
+			getManager().createQueryBuilder(Comment, "comment").getCount(),
+			getManager().createQueryBuilder(User, "user").getCount(),
+		]);
 		return {
 			numAudioItemsAllTime,
 			numTagsAllTime,
+			numCommentsAllTime,
 			numUsersAllTime,
 		};
 	}

--- a/api/src/resolvers/StatsResolver.ts
+++ b/api/src/resolvers/StatsResolver.ts
@@ -1,0 +1,35 @@
+import { Resolver, Int, Query, ObjectType, Field } from "type-graphql";
+import { getManager } from "typeorm";
+import { AudioItem } from "../models/entities/AudioItem";
+import { Tag } from "../models/Tag";
+import { User } from "../models/User";
+
+@ObjectType()
+class Stats {
+	@Field(() => Int)
+	numAudioItemsAllTime!: number;
+
+	@Field(() => Int)
+	numTagsAllTime!: number;
+
+	@Field(() => Int)
+	numUsersAllTime!: number;
+}
+
+@Resolver()
+export class StatsResolver {
+	@Query(() => Stats)
+	async stats() {
+		const [numAudioItemsAllTime, numTagsAllTime, numUsersAllTime] =
+			await Promise.all<number>([
+				getManager().createQueryBuilder(AudioItem, "audioItem").getCount(),
+				getManager().createQueryBuilder(Tag, "tag").getCount(),
+				getManager().createQueryBuilder(User, "user").getCount(),
+			]);
+		return {
+			numAudioItemsAllTime,
+			numTagsAllTime,
+			numUsersAllTime,
+		};
+	}
+}

--- a/web/components/AudioItem.tsx
+++ b/web/components/AudioItem.tsx
@@ -14,12 +14,12 @@ interface Props {
 // AudioItem handles wrapping the different variants of AudioItem components. It
 // returns the variant requested in the `viewAs` prop. Default is Card.
 const AudioItemComponent = ({
-	viewAs = ViewAs.Card,
+	viewAs = ViewAs.Cards,
 	audioItem,
 	showTitle,
 	className,
 }: Props) => {
-	if (viewAs === ViewAs.Card) {
+	if (viewAs === ViewAs.Cards) {
 		return (
 			<AudioItemCard
 				audioItem={audioItem}

--- a/web/components/AudioItemCard.tsx
+++ b/web/components/AudioItemCard.tsx
@@ -153,7 +153,7 @@ const AudioItemCard = ({ audioItem, showTitle = true, className }: Props) => {
 					)}{" "}
 					{DateTime.formatDateYearTime(createdAt)}
 				</div>
-				<div className="text-sm mt-1 text-gray-900 whitespace-pre-line">
+				<div className="text-sm mt-1 text-gray-900 whitespace-pre-wrap">
 					{description || "No description"}
 				</div>
 			</div>

--- a/web/components/Filters.tsx
+++ b/web/components/Filters.tsx
@@ -117,7 +117,7 @@ const Filters = ({
 				<div className="flex flex-row items-center mr-0 md:mb-0">
 					View as
 					<select className="ml-1" value={viewAs} onChange={onChangeViewAs}>
-						<option value={ViewAs.Card}>Cards</option>
+						<option value={ViewAs.Cards}>Cards</option>
 						<option value={ViewAs.Compact}>Compact</option>
 						<option value={ViewAs.List}>List</option>
 					</select>

--- a/web/components/SearchEntities.tsx
+++ b/web/components/SearchEntities.tsx
@@ -121,7 +121,12 @@ const SearchEntities = ({
 									className="flex flex-1 justify-between items-center text-left p-2 rounded cursor-pointer hover:bg-gray-200"
 									onClick={() => onSelect(entity)}
 								>
-									<span>{entity.name}</span>
+									<span>
+										{entity.name}
+										{entity.entityType === EntityType.Tune
+											? ` (${entity.type})`
+											: ""}
+									</span>
 									<span className="uppercase text-gray-500 text-sm">
 										{entity.entityType}
 									</span>

--- a/web/components/ViewEntity.tsx
+++ b/web/components/ViewEntity.tsx
@@ -28,7 +28,7 @@ const ViewEntity = ({ entity, className }: Props) => {
 		defaultPage: 1,
 		totalItems: totalAudioItems,
 		defaultPerPage: PerPage.Twenty,
-		defaultViewAs: ViewAs.Card,
+		defaultViewAs: ViewAs.Cards,
 	});
 	const filtersRef = useRef<HTMLDivElement>(null);
 

--- a/web/components/ViewEntityAndAudioItems.tsx
+++ b/web/components/ViewEntityAndAudioItems.tsx
@@ -28,7 +28,7 @@ const ViewEntityAndAudioItems = ({ entity, className }: Props) => {
 		defaultPage: 1,
 		totalItems: totalAudioItems,
 		defaultPerPage: PerPage.Twenty,
-		defaultViewAs: ViewAs.Card,
+		defaultViewAs: ViewAs.Cards,
 	});
 	const filtersRef = useRef<HTMLDivElement>(null);
 

--- a/web/hooks/useQueryParams.ts
+++ b/web/hooks/useQueryParams.ts
@@ -1,0 +1,67 @@
+import { useCallback, useMemo } from "react";
+import { useRouter } from "next/router";
+
+interface ReturnValue {
+	getQueryParams: () => Record<string, string>;
+	updateQueryParams: (paramsToUpdate: Record<string, string | null>) => void;
+	clearQueryParams: () => void;
+}
+const useQueryParams = (): ReturnValue => {
+	const router = useRouter();
+
+	const getQueryParams = useCallback(() => {
+		if (typeof window === "undefined") {
+			return {};
+		}
+		const queryParams = new URLSearchParams(window.location.search);
+		const outputObject = {};
+		for (const key of queryParams.keys()) {
+			outputObject[key] = queryParams.get(key);
+		}
+		return outputObject;
+	}, []);
+
+	const updateQueryParams = useCallback(
+		(paramsToUpdate: Record<string, string | null> = {}) => {
+			if (typeof window === "undefined") {
+				return;
+			}
+			const queryParams = new URLSearchParams(window.location.search);
+
+			const paramNames = Object.keys(paramsToUpdate);
+			paramNames.forEach((paramName) => {
+				const value = paramsToUpdate[paramName];
+				if (value) {
+					queryParams.set(paramName, value);
+				} else {
+					queryParams.delete(paramName);
+				}
+			});
+
+			return router.push(
+				`${window.location.pathname}?${queryParams.toString()}`
+			);
+		},
+		[router]
+	);
+
+	const clearQueryParams = useCallback(() => {
+		if (typeof window === "undefined") {
+			return;
+		}
+		router.push(window.location.pathname);
+	}, [router]);
+
+	const returnValue = useMemo(
+		() => ({
+			getQueryParams,
+			updateQueryParams,
+			clearQueryParams,
+		}),
+		[getQueryParams, updateQueryParams, clearQueryParams]
+	);
+
+	return returnValue;
+};
+
+export default useQueryParams;

--- a/web/pages/entities/audio-items/[slug].tsx
+++ b/web/pages/entities/audio-items/[slug].tsx
@@ -53,7 +53,7 @@ const ViewAudioItemBySlug = () => {
 						<Link href={EntityService.makeHrefForAbout(audioItem)}>About</Link>
 					</div>
 					<AudioItemComponent
-						viewAs={ViewAs.Card}
+						viewAs={ViewAs.Cards}
 						audioItem={audioItem}
 						showTitle={false}
 					/>

--- a/web/pages/entities/collections/[slug]/about.tsx
+++ b/web/pages/entities/collections/[slug]/about.tsx
@@ -54,7 +54,9 @@ const CollectionAbout = () => {
 						<div className="mb-4">
 							Description:
 							<br />
-							<span className="text-gray-500">{description}</span>
+							<span className="text-gray-500 whitespace-pre">
+								{description}
+							</span>
 						</div>
 					)}
 					{aliases && (

--- a/web/pages/entities/collections/[slug]/about.tsx
+++ b/web/pages/entities/collections/[slug]/about.tsx
@@ -54,7 +54,7 @@ const CollectionAbout = () => {
 						<div className="mb-4">
 							Description:
 							<br />
-							<span className="text-gray-500 whitespace-pre">
+							<span className="text-gray-500 whitespace-pre-wrap">
 								{description}
 							</span>
 						</div>

--- a/web/pages/entities/instruments/[slug]/about.tsx
+++ b/web/pages/entities/instruments/[slug]/about.tsx
@@ -40,7 +40,7 @@ const InstrumentAbout = () => {
 						<div className="mb-4">
 							Description:
 							<br />
-							<span className="text-gray-500 whitespace-pre">
+							<span className="text-gray-500 whitespace-pre-wrap">
 								{description}
 							</span>
 						</div>

--- a/web/pages/entities/people/[slug]/about.tsx
+++ b/web/pages/entities/people/[slug]/about.tsx
@@ -40,7 +40,7 @@ const PersonAbout = () => {
 						<div className="mb-4">
 							Description:
 							<br />
-							<span className="text-gray-500 whitespace-pre">
+							<span className="text-gray-500 whitespace-pre-wrap">
 								{description}
 							</span>
 						</div>

--- a/web/pages/entities/places/[slug]/about.tsx
+++ b/web/pages/entities/places/[slug]/about.tsx
@@ -40,7 +40,7 @@ const PlaceAbout = () => {
 						<div className="mb-4">
 							Description:
 							<br />
-							<span className="text-gray-500 whitespace-pre">
+							<span className="text-gray-500 whitespace-pre-wrap">
 								{description}
 							</span>
 						</div>

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -3,6 +3,7 @@ import {
 	ApolloClient,
 	InMemoryCache,
 	NormalizedCacheObject,
+	gql,
 } from "@apollo/client";
 import Link from "next/link";
 
@@ -14,6 +15,7 @@ import {
 	EntityStatus,
 	SortBy,
 	ViewAs,
+	Stats,
 } from "types";
 import useAudioItems, { AUDIO_ITEMS_QUERY } from "hooks/useAudioItems";
 import useComments, { COMMENTS_QUERY } from "hooks/useComments";
@@ -31,6 +33,16 @@ import LoadingBlock from "components/LoadingBlock";
 const NUM_AUDIO_ITEMS_TO_FETCH = 10;
 const NUM_COMMENTS_TO_FETCH = 6;
 const NUM_COLLECTIONS_TO_FETCH = 5;
+
+const STATS_QUERY = gql`
+	query Stats {
+		stats {
+			numAudioItemsAllTime
+			numTagsAllTime
+			numCommentsAllTime
+		}
+	}
+`;
 
 interface QueryVariables {
 	input: {
@@ -50,6 +62,7 @@ let serverSideApolloClient: ApolloClient<NormalizedCacheObject> | undefined;
 export async function getStaticProps() {
 	let recentlyTaggedAudioItems: AudioItem[] | undefined;
 	let recentlyAddedAudioItems: AudioItem[] | undefined;
+	let stats: Stats | undefined;
 	let comments: Comment[] | undefined;
 	let collections: Collection[] | undefined;
 
@@ -100,7 +113,10 @@ export async function getStaticProps() {
 				}),
 			]);
 
-		const [commentsQuery, collectionsQuery] = await Promise.all([
+		const [statsQuery, commentsQuery, collectionsQuery] = await Promise.all([
+			serverSideApolloClient.query<{ stats: Stats }>({
+				query: STATS_QUERY,
+			}),
 			serverSideApolloClient.query<{ comments: Comment[] }, QueryVariables>({
 				query: COMMENTS_QUERY,
 				variables: {
@@ -125,6 +141,7 @@ export async function getStaticProps() {
 
 		recentlyTaggedAudioItems = recentlyTaggedAudioItemsQuery?.data?.audioItems;
 		recentlyAddedAudioItems = recentlyAddedAudioItemsQuery?.data?.audioItems;
+		stats = statsQuery?.data?.stats;
 		comments = commentsQuery?.data?.comments;
 		collections = collectionsQuery?.data?.collections;
 	} catch {
@@ -135,6 +152,7 @@ export async function getStaticProps() {
 		props: {
 			prefetchedRecentlyTaggedAudioItems: recentlyTaggedAudioItems ?? null,
 			prefetchedRecentlyAddedAudioItems: recentlyAddedAudioItems ?? null,
+			prefetchedStats: stats ?? null,
 			prefetchedComments: comments ?? null,
 			prefetchedCollections: collections ?? null,
 		},
@@ -145,6 +163,7 @@ export async function getStaticProps() {
 interface Props {
 	prefetchedRecentlyTaggedAudioItems?: AudioItem[];
 	prefetchedRecentlyAddedAudioItems?: AudioItem[];
+	prefetchedStats?: Stats;
 	prefetchedComments?: Comment[];
 	prefetchedCollections?: Collection[];
 }
@@ -152,6 +171,7 @@ interface Props {
 export default function Home({
 	prefetchedRecentlyTaggedAudioItems,
 	prefetchedRecentlyAddedAudioItems,
+	prefetchedStats,
 	prefetchedComments,
 	prefetchedCollections,
 }: Props) {
@@ -215,6 +235,19 @@ export default function Home({
 				});
 			}
 		}
+		if (prefetchedStats) {
+			// Check if there are already Stats in the cache
+			const cachedStats = apolloClient.readQuery({
+				query: STATS_QUERY,
+			});
+			// If not, add the prefetched Stats to the cache
+			if (!cachedStats) {
+				apolloClient.writeQuery({
+					query: STATS_QUERY,
+					data: { stats: prefetchedStats },
+				});
+			}
+		}
 		if (prefetchedComments) {
 			// Check if there are already Comments in the cache
 			const cachedComments = apolloClient.readQuery({
@@ -267,6 +300,7 @@ export default function Home({
 		apolloClient,
 		prefetchedRecentlyTaggedAudioItems,
 		prefetchedRecentlyAddedAudioItems,
+		prefetchedStats,
 		prefetchedComments,
 		prefetchedCollections,
 	]);
@@ -393,6 +427,17 @@ export default function Home({
 					<Link href="/entities/collections">
 						<a className="mb-2">Collections</a>
 					</Link>
+
+					<h3 className="mt-6 mb-4">Stats</h3>
+					<span className="mb-2 text-gray-500">
+						{prefetchedStats.numAudioItemsAllTime} Audio Items
+					</span>
+					<span className="mb-2 text-gray-500">
+						{prefetchedStats.numTagsAllTime} Tags
+					</span>
+					<span className="mb-2 text-gray-500">
+						{prefetchedStats.numCommentsAllTime} Comments
+					</span>
 
 					<h3 className="mt-6 mb-4">Latest Collections</h3>
 					{collectionsLoading && collections?.length === 0 && <LoadingBlock />}

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -274,6 +274,7 @@ export default function Home({
 	const { Filters, filtersProps, sortBy, viewAs } = useFilters({
 		defaultSortBy: SortBy.RecentlyTagged,
 		defaultViewAs: ViewAs.Card,
+		enableQueryParams: false,
 	});
 
 	// These queries skip the initial network request if the cache was

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -273,7 +273,7 @@ export default function Home({
 
 	const { Filters, filtersProps, sortBy, viewAs } = useFilters({
 		defaultSortBy: SortBy.RecentlyTagged,
-		defaultViewAs: ViewAs.Card,
+		defaultViewAs: ViewAs.Cards,
 		enableQueryParams: false,
 	});
 

--- a/web/pages/index.tsx
+++ b/web/pages/index.tsx
@@ -428,16 +428,20 @@ export default function Home({
 						<a className="mb-2">Collections</a>
 					</Link>
 
-					<h3 className="mt-6 mb-4">Stats</h3>
-					<span className="mb-2 text-gray-500">
-						{prefetchedStats.numAudioItemsAllTime} Audio Items
-					</span>
-					<span className="mb-2 text-gray-500">
-						{prefetchedStats.numTagsAllTime} Tags
-					</span>
-					<span className="mb-2 text-gray-500">
-						{prefetchedStats.numCommentsAllTime} Comments
-					</span>
+					{prefetchedStats && (
+						<>
+							<h3 className="mt-6 mb-4">Stats</h3>
+							<span className="mb-2 text-gray-500">
+								{prefetchedStats.numAudioItemsAllTime} Audio Items
+							</span>
+							<span className="mb-2 text-gray-500">
+								{prefetchedStats.numTagsAllTime} Tags
+							</span>
+							<span className="mb-2 text-gray-500">
+								{prefetchedStats.numCommentsAllTime} Comments
+							</span>
+						</>
+					)}
 
 					<h3 className="mt-6 mb-4">Latest Collections</h3>
 					{collectionsLoading && collections?.length === 0 && <LoadingBlock />}
@@ -457,6 +461,15 @@ export default function Home({
 							</div>
 						);
 					})}
+
+					<h3 className="mt-6 mb-4">Latest Features + Fixes</h3>
+					<a
+						className="mb-2"
+						href="https://github.com/dgurns/trad-archive/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc"
+						target="_blank"
+					>
+						View on GitHub <i className="material-icons text-sm">launch</i>
+					</a>
 
 					<h3 className="mt-6 mb-4">Latest Comments</h3>
 					{commentsLoading && comments?.length === 0 && <LoadingBlock />}

--- a/web/pages/users/[id].tsx
+++ b/web/pages/users/[id].tsx
@@ -43,7 +43,7 @@ const ViewUserById = () => {
 	] = useAudioItemsCreatedByUser(userData?.user);
 
 	const { Filters, filtersProps, viewAs } = useFilters({
-		defaultViewAs: ViewAs.Card,
+		defaultViewAs: ViewAs.Cards,
 	});
 
 	const aboutMarkup = useMemo(

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -12,7 +12,7 @@ export enum SortBy {
 }
 
 export enum ViewAs {
-	Card = "Card",
+	Cards = "Cards",
 	Compact = "Compact",
 	List = "List",
 }

--- a/web/types/index.ts
+++ b/web/types/index.ts
@@ -230,3 +230,9 @@ export const isApprovedVerificationRequest = (
 export const isDeniedVerificationRequest = (
 	verificationRequest: VerificationRequest
 ) => verificationRequest.status.valueOf() === "Denied";
+
+export interface Stats {
+	numAudioItemsAllTime: number;
+	numTagsAllTime: number;
+	numCommentsAllTime: number;
+}


### PR DESCRIPTION
- Improve text matching in searches
- Keep track of current filters in URL query params. This enables direct links to, say, Page 3 of a Collection. It also enables the back button in the browser to take you to the results page you were on.
- Add stats and a link to the GitHub changelog to the homepage
- Closes #62 