### PR TITLE
Enable tagging with same entity at different timestamps; Improve audio loading; Improve timestamp UI

### DIFF
--- a/api/src/resolvers/TagResolver.ts
+++ b/api/src/resolvers/TagResolver.ts
@@ -77,6 +77,9 @@ export class TagResolver {
 				objectEntityId,
 			})
 			.andWhere("tag.relationshipId = :relationshipId", { relationshipId })
+			.andWhere("tag.subjectTimeMarkerSeconds = :subjectTimeMarkerSeconds", {
+				subjectTimeMarkerSeconds,
+			})
 			.getOne();
 		if (existingTag) {
 			throw new Error("This Tag has already been added");

--- a/web/components/AudioItemCard.tsx
+++ b/web/components/AudioItemCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 
@@ -11,7 +11,6 @@ import {
 } from "types";
 import DateTime from "services/DateTime";
 import usePlayerContext from "hooks/usePlayerContext";
-import useAudioItem from "hooks/useAudioItem";
 
 import Tags from "components/Tags";
 import Menu from "components/Menu";

--- a/web/components/AudioItemCompact.tsx
+++ b/web/components/AudioItemCompact.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import Link from "next/link";
 
-import { AudioItem, EntityStatus } from "types";
+import { AudioItem, EntityStatus, EntityType } from "types";
 import EntityService from "services/Entity";
 import TagService from "services/Tag";
 import usePlayerContext from "hooks/usePlayerContext";
@@ -67,7 +67,12 @@ const AudioItemCompact = ({ audioItem, className }: Props) => {
 					{sortedTags.map((tag, index) => (
 						<div key={index} className="ml-1 whitespace-pre">
 							<Link href={EntityService.makeHrefForView(tag.objectEntity)}>
-								{tag.objectEntity.name}
+								<a>
+									{tag.objectEntity.name}
+									{tag.objectEntity.entityType === EntityType.Tune
+										? ` (${tag.objectEntity.type})`
+										: ""}
+								</a>
 							</Link>
 							{index !== sortedTags.length - 1 && ", "}
 						</div>

--- a/web/components/AudioPlayer.tsx
+++ b/web/components/AudioPlayer.tsx
@@ -53,6 +53,7 @@ const AudioPlayer = ({ item }: AudioPlayerProps) => {
 		<audio
 			ref={audioPlayerRef}
 			id="audio"
+			preload="metadata"
 			autoPlay
 			controls
 			controlsList="nodownload"

--- a/web/components/CreateTagForm.tsx
+++ b/web/components/CreateTagForm.tsx
@@ -231,7 +231,7 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 					/>
 					<label htmlFor="time-marker" className="ml-2">
 						<div className="flex flex-col items-start">
-							<div className="mb-2">Mark this tag at time:</div>
+							<div className="mb-2">Mark this Tag at time:</div>
 							<TimestampInput
 								valueInSeconds={timeMarkerValue}
 								onChange={onTimeMarkerValueChanged}

--- a/web/components/CreateTagForm.tsx
+++ b/web/components/CreateTagForm.tsx
@@ -102,13 +102,13 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 
 	const onTimeMarkerValueChanged = useCallback(
 		(newTimeMarkerValueSeconds: number) => {
-			if (newTimeMarkerValueSeconds > activeItemDurationSeconds) {
+			setShouldAddTimeMarker(true);
+			if (newTimeMarkerValueSeconds >= activeItemDurationSeconds) {
 				setTimeMarkerValue(activeItemDurationSeconds);
-				return;
+			} else if (newTimeMarkerValueSeconds <= 0) {
+				setTimeMarkerValue(0);
 			} else {
-				setShouldAddTimeMarker(true);
 				setTimeMarkerValue(newTimeMarkerValueSeconds);
-				return;
 			}
 		},
 		[activeItemDurationSeconds]

--- a/web/components/CreateTagForm.tsx
+++ b/web/components/CreateTagForm.tsx
@@ -7,6 +7,7 @@ import useTags from "hooks/useTags";
 
 import SearchEntities from "components/SearchEntities";
 import SelectRelationship from "components/SelectRelationship";
+import TimestampInput from "components/TimestampInput";
 
 const CREATE_TAG_MUTATION = gql`
 	mutation CreateTag($input: CreateTagInput!) {
@@ -100,22 +101,17 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 	}, []);
 
 	const onTimeMarkerValueChanged = useCallback(
-		(event) => {
-			const newTimeMarkerValue = parseInt(event.target.value);
-			if (isNaN(newTimeMarkerValue)) {
-				setShouldAddTimeMarker(false);
-				setTimeMarkerValue(NaN);
-				return;
-			} else if (newTimeMarkerValue > activeItemDurationSeconds) {
+		(newTimeMarkerValueSeconds: number) => {
+			if (newTimeMarkerValueSeconds > activeItemDurationSeconds) {
 				setTimeMarkerValue(activeItemDurationSeconds);
 				return;
 			} else {
 				setShouldAddTimeMarker(true);
-				setTimeMarkerValue(newTimeMarkerValue);
+				setTimeMarkerValue(newTimeMarkerValueSeconds);
 				return;
 			}
 		},
-		[playbackPositionSeconds, activeItemDurationSeconds]
+		[activeItemDurationSeconds]
 	);
 
 	const onSelectRelationship = useCallback(
@@ -192,7 +188,7 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 		<>
 			<div>What is the relationship between these two entities?</div>
 
-			<div className="mt-3">
+			<div className="mt-2">
 				<SelectRelationship
 					subjectEntity={entity}
 					objectEntity={selectedEntity}
@@ -215,7 +211,7 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 			</div>
 
 			{shouldCreateInverseRelationship && (
-				<div className="mt-3">
+				<div className="mt-2">
 					<SelectRelationship
 						subjectEntity={selectedEntity}
 						objectEntity={entity}
@@ -225,24 +221,21 @@ const CreateTagForm = ({ entity, onSuccess }: Props) => {
 			)}
 
 			{shouldShowTimeMarkerCheckbox && (
-				<div className="mt-4 flex flex-row items-center justify-start">
+				<div className="mt-6 flex flex-row items-start justify-start">
 					<input
 						type="checkbox"
 						id="time-marker"
+						className="mt-1"
 						checked={shouldAddTimeMarker}
 						onChange={(event) => setShouldAddTimeMarker(event.target.checked)}
 					/>
 					<label htmlFor="time-marker" className="ml-2">
-						<div className="flex flex-row items-center">
-							Mark this tag at time{" "}
-							<div className="w-16 mx-2">
-								<input
-									type="number"
-									value={timeMarkerValue}
-									onChange={onTimeMarkerValueChanged}
-								/>{" "}
-							</div>
-							second{timeMarkerValue === 1 ? "" : "s"}
+						<div className="flex flex-col items-start">
+							<div className="mb-2">Mark this tag at time:</div>
+							<TimestampInput
+								valueInSeconds={timeMarkerValue}
+								onChange={onTimeMarkerValueChanged}
+							/>
 						</div>
 					</label>
 				</div>

--- a/web/components/TimeMarkers.tsx
+++ b/web/components/TimeMarkers.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import Link from "next/link";
 
-import { AudioItem, Tag } from "types";
+import { AudioItem, EntityType, Tag } from "types";
 import DateTime from "services/DateTime";
 import Entity from "services/Entity";
 import usePlayerContext from "hooks/usePlayerContext";
@@ -95,7 +95,12 @@ const TimeMarkers = ({ audioItem }: Props) => {
 								{tagsAtTimeMarker.map((tag, index) => (
 									<span className="flex flex-row items-center" key={index}>
 										<Link href={Entity.makeHrefForView(tag.objectEntity)}>
-											<a id="time-marker-tag-link">{tag.objectEntity.name}</a>
+											<a id="time-marker-tag-link">
+												{tag.objectEntity.name}
+												{tag.objectEntity.entityType === EntityType.Tune
+													? ` (${tag.objectEntity.type})`
+													: ""}
+											</a>
 										</Link>
 										{index !== tagsAtTimeMarker.length - 1 && (
 											<span className="hidden md:block mr-1">,</span>

--- a/web/components/TimestampInput.tsx
+++ b/web/components/TimestampInput.tsx
@@ -27,13 +27,17 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 		onChange(newValueInSeconds);
 	};
 
+	const hrsValue = valueInSeconds === 0 ? 0 : hrs || "";
+	const minsValue = valueInSeconds === 0 ? 0 : mins || "";
+	const secsValue = valueInSeconds === 0 ? 0 : secs || "";
+
 	return (
 		<div className={`flex flex-row items-center ${className ?? ""}`}>
 			<input
 				type="number"
 				id="hrs"
 				className="flex max-w-[50px]"
-				value={hrs || null}
+				value={hrsValue}
 				onChange={onChangeHrs}
 			/>
 			<label htmlFor="hours" className="px-2">
@@ -43,7 +47,7 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 				type="number"
 				id="mins"
 				className="flex max-w-[55px]"
-				value={mins || null}
+				value={minsValue}
 				onChange={onChangeMins}
 			/>
 			<label htmlFor="mins" className="px-2">
@@ -53,7 +57,7 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 				type="number"
 				id="secs"
 				className="flex max-w-[55px]"
-				value={secs || null}
+				value={secsValue}
 				onChange={onChangeSecs}
 			/>
 			<label htmlFor="secs" className="px-2">

--- a/web/components/TimestampInput.tsx
+++ b/web/components/TimestampInput.tsx
@@ -1,0 +1,66 @@
+interface Props {
+	valueInSeconds: number;
+	onChange: (valueInSeconds: number) => void;
+	className?: string;
+}
+
+const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
+	const hrs = Math.floor(valueInSeconds / 3600);
+	const mins = Math.floor((valueInSeconds - hrs * 3600) / 60);
+	const secs = valueInSeconds - hrs * 3600 - mins * 60;
+
+	const onChangeHrs = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const newHrs = parseInt(event.target.value, 10) || 0;
+		const newValueInSeconds = newHrs * 3600 + mins * 60 + secs;
+		onChange(newValueInSeconds);
+	};
+
+	const onChangeMins = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const newMins = parseInt(event.target.value, 10) || 0;
+		const newValueInSeconds = hrs * 3600 + newMins * 60 + secs;
+		onChange(newValueInSeconds);
+	};
+
+	const onChangeSecs = (event: React.ChangeEvent<HTMLInputElement>) => {
+		const newSecs = parseInt(event.target.value, 10) || 0;
+		const newValueInSeconds = hrs * 3600 + mins * 60 + newSecs;
+		onChange(newValueInSeconds);
+	};
+
+	return (
+		<div className={`flex flex-row items-center ${className ?? ""}`}>
+			<input
+				type="number"
+				id="hrs"
+				className="flex max-w-[50px]"
+				value={hrs || null}
+				onChange={onChangeHrs}
+			/>
+			<label htmlFor="hours" className="px-2">
+				hr{hrs !== 1 && "s"}
+			</label>
+			<input
+				type="number"
+				id="mins"
+				className="flex max-w-[55px]"
+				value={mins || null}
+				onChange={onChangeMins}
+			/>
+			<label htmlFor="mins" className="px-2">
+				min{mins !== 1 ? "s" : ""}
+			</label>
+			<input
+				type="number"
+				id="secs"
+				className="flex max-w-[55px]"
+				value={secs || null}
+				onChange={onChangeSecs}
+			/>
+			<label htmlFor="secs" className="px-2">
+				sec{secs !== 1 ? "s" : ""}
+			</label>
+		</div>
+	);
+};
+
+export default TimestampInput;

--- a/web/components/TimestampInput.tsx
+++ b/web/components/TimestampInput.tsx
@@ -27,17 +27,14 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 		onChange(newValueInSeconds);
 	};
 
-	const hrsValue = valueInSeconds === 0 ? 0 : hrs || "";
-	const minsValue = valueInSeconds === 0 ? 0 : mins || "";
-	const secsValue = valueInSeconds === 0 ? 0 : secs || "";
-
 	return (
 		<div className={`flex flex-row items-center ${className ?? ""}`}>
 			<input
 				type="number"
 				id="hrs"
 				className="flex max-w-[50px]"
-				value={hrsValue}
+				value={hrs || ""}
+				placeholder="0"
 				onChange={onChangeHrs}
 			/>
 			<label htmlFor="hours" className="px-2">
@@ -47,7 +44,8 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 				type="number"
 				id="mins"
 				className="flex max-w-[55px]"
-				value={minsValue}
+				value={mins || ""}
+				placeholder="0"
 				onChange={onChangeMins}
 			/>
 			<label htmlFor="mins" className="px-2">
@@ -57,7 +55,8 @@ const TimestampInput = ({ valueInSeconds, onChange, className }: Props) => {
 				type="number"
 				id="secs"
 				className="flex max-w-[55px]"
-				value={secsValue}
+				value={secs || ""}
+				placeholder="0"
 				onChange={onChangeSecs}
 			/>
 			<label htmlFor="secs" className="px-2">

--- a/web/fragments/index.ts
+++ b/web/fragments/index.ts
@@ -76,6 +76,7 @@ export const TagEntityFragments = {
 			entityType
 			name
 			slug
+			type
 		}
 	`,
 	tagCollection: gql`


### PR DESCRIPTION
- Fixes #66 
- Now you can tag the same entity at different timestamps
<img width="742" alt="Screen Shot 2022-03-03 at 4 13 10 PM" src="https://user-images.githubusercontent.com/1173791/156607056-c436fbf6-702e-4db6-8f28-cc186a08e11b.png">

- When starting audio playback at a timestamp, initial load should start at the timestamp instead of the beginning
- When tagging something at a timestamp, make a more user-friendly interface
<img width="458" alt="Screen Shot 2022-03-03 at 4 02 26 PM" src="https://user-images.githubusercontent.com/1173791/156607100-c19ad5e1-51d1-4d18-96fd-8d75ff896eba.png">

